### PR TITLE
Enable Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: go
+
+go:
+    - 1.8
+    - 1.9
+    - tip
+
+go_import_path: github.com/intel/govmm
+
+matrix:
+  allow_failures:
+  - go: tip
+
+before_install:
+  - go get github.com/alecthomas/gometalinter
+  - gometalinter --install
+
+script:
+   - go env
+   - go test -v ./...
+   - gometalinter --tests --vendor --disable-all --enable=misspell --enable=vet --enable=ineffassign --enable=gofmt --enable=gocyclo --cyclo-over=15 --enable=golint --enable=errcheck --enable=deadcode ./...

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -146,10 +146,10 @@ func TestAppendDeviceNetworkMq(t *testing.T) {
 	bar, _ := ioutil.TempFile(os.TempDir(), "govmm-qemu-test")
 
 	defer func() {
-		foo.Close()
-		bar.Close()
-		os.Remove(foo.Name())
-		os.Remove(bar.Name())
+		_ = foo.Close()
+		_ = bar.Close()
+		_ = os.Remove(foo.Name())
+		_ = os.Remove(bar.Name())
 	}()
 
 	netdev := NetDevice{
@@ -196,10 +196,10 @@ func TestAppendDeviceNetworkPCIMq(t *testing.T) {
 	bar, _ := ioutil.TempFile(os.TempDir(), "govmm-qemu-test")
 
 	defer func() {
-		foo.Close()
-		bar.Close()
-		os.Remove(foo.Name())
-		os.Remove(bar.Name())
+		_ = foo.Close()
+		_ = bar.Close()
+		_ = os.Remove(foo.Name())
+		_ = os.Remove(bar.Name())
 	}()
 
 	netdev := NetDevice{


### PR DESCRIPTION
This commit adds a .travis file which enables Travis builds for
govmm.  The script builds the source and runs the unit tests
and gometalinter enabling

- misspell
- vet
- ineffassign
- gofmt
- gocyclo 15
- golint
- errcheck
- deadcode

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>