### PR TITLE
Vhost-user:  add block device support

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -704,7 +704,7 @@ func (blkdev BlockDevice) QemuParams(config *Config) []string {
 	return qemuParams
 }
 
-// VhostUserDeviceType is a qemu networking device type.
+// VhostUserDeviceType is a qemu vhost-user device type.
 type VhostUserDeviceType string
 
 const (
@@ -714,21 +714,21 @@ const (
 	VhostUserNet = "virtio-net-pci"
 )
 
-// VhostUserDevice represents a qemu vhost-user network device meant to be passed
+// VhostUserDevice represents a qemu vhost-user device meant to be passed
 // in to the guest
 type VhostUserDevice struct {
 	SocketPath    string //path to vhostuser socket on host
 	CharDevID     string
-	TypeDevID     string //id (SCSI) or netdev (net) device parameter
-	MacAddress    string //only valid if device type is  VhostUserNet
+	TypeDevID     string //variable QEMU parameter based on value of VhostUserType
+	Address       string //used for MAC address in net case
 	VhostUserType VhostUserDeviceType
 }
 
-// Valid returns true if there is a valid socket path defined for VhostUserDevice
+// Valid returns true if there is a valid structure defined for VhostUserDevice
 func (vhostuserDev VhostUserDevice) Valid() bool {
 	if vhostuserDev.SocketPath == "" || vhostuserDev.CharDevID == "" ||
 		vhostuserDev.TypeDevID == "" ||
-		(vhostuserDev.VhostUserType == VhostUserNet && vhostuserDev.MacAddress == "") {
+		(vhostuserDev.VhostUserType == VhostUserNet && vhostuserDev.Address == "") {
 		return false
 	}
 
@@ -755,7 +755,7 @@ func (vhostuserDev VhostUserDevice) QemuParams(config *Config) []string {
 
 		devParams = append(devParams, VhostUserNet)
 		devParams = append(devParams, fmt.Sprintf("netdev=%s", vhostuserDev.TypeDevID))
-		devParams = append(devParams, fmt.Sprintf("mac=%s", vhostuserDev.MacAddress))
+		devParams = append(devParams, fmt.Sprintf("mac=%s", vhostuserDev.Address))
 	} else {
 		devParams = append(devParams, VhostUserSCSI)
 		devParams = append(devParams, fmt.Sprintf("id=%s", vhostuserDev.TypeDevID))

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -273,7 +273,7 @@ func TestAppendDeviceVhostUser(t *testing.T) {
 		SocketPath:    "/tmp/nonexistentsocket.socket",
 		CharDevID:     "char1",
 		TypeDevID:     "scsi1",
-		MacAddress:    "",
+		Address:       "",
 		VhostUserType: VhostUserSCSI,
 	}
 	testAppend(vhostuserSCSIDevice, deviceVhostUserSCSIString, t)
@@ -282,7 +282,7 @@ func TestAppendDeviceVhostUser(t *testing.T) {
 		SocketPath:    "/tmp/nonexistentsocket.socket",
 		CharDevID:     "char1",
 		TypeDevID:     "net1",
-		MacAddress:    "00:11:22:33:44:55",
+		Address:       "00:11:22:33:44:55",
 		VhostUserType: VhostUserNet,
 	}
 	testAppend(vhostuserNetDevice, deviceVhostUserNetString, t)

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -267,8 +267,19 @@ func TestAppendDeviceBlock(t *testing.T) {
 
 var deviceVhostUserNetString = "-chardev socket,id=char1,path=/tmp/nonexistentsocket.socket -netdev type=vhost-user,id=net1,chardev=char1,vhostforce -device virtio-net-pci,netdev=net1,mac=00:11:22:33:44:55"
 var deviceVhostUserSCSIString = "-chardev socket,id=char1,path=/tmp/nonexistentsocket.socket -device vhost-user-scsi-pci,id=scsi1,chardev=char1"
+var deviceVhostUserBlkString = "-chardev socket,id=char2,path=/tmp/nonexistentsocket.socket -device vhost-user-blk-pci,logical_block_size=4096,size=512M,chardev=char2"
 
 func TestAppendDeviceVhostUser(t *testing.T) {
+
+	vhostuserBlkDevice := VhostUserDevice{
+		SocketPath:    "/tmp/nonexistentsocket.socket",
+		CharDevID:     "char2",
+		TypeDevID:     "",
+		Address:       "",
+		VhostUserType: VhostUserBlk,
+	}
+	testAppend(vhostuserBlkDevice, deviceVhostUserBlkString, t)
+
 	vhostuserSCSIDevice := VhostUserDevice{
 		SocketPath:    "/tmp/nonexistentsocket.socket",
 		CharDevID:     "char1",


### PR DESCRIPTION
A couple of patches for fixing up comments/naming as well as addition of basic vhost-user block device support.

To do still:
-exercise in complete stack (through pulling changes into CC-runtime)
-Add multiqueue support
-Add parameterization for block device fields.