### PR TITLE
scsi: Add a scsi controller device

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -825,6 +825,45 @@ func (vfioDev VFIODevice) QemuParams(config *Config) []string {
 	return qemuParams
 }
 
+// SCSIController represents a SCSI controller device.
+type SCSIController struct {
+	ID string
+
+	// Bus on which the SCSI controller is attached, this is optional
+	Bus string
+
+	// Addr is the PCI address offset, this is optional
+	Addr string
+}
+
+// Valid returns true if the SCSIController structure is valid and complete.
+func (scsiCon SCSIController) Valid() bool {
+	if scsiCon.ID == "" {
+		return false
+	}
+
+	return true
+}
+
+// QemuParams returns the qemu parameters built out of this SCSIController device.
+func (scsiCon SCSIController) QemuParams(config *Config) []string {
+	var qemuParams []string
+	var devParams []string
+
+	devParams = append(devParams, fmt.Sprintf("virtio-scsi-pci,id=%s", scsiCon.ID))
+	if scsiCon.Bus != "" {
+		devParams = append(devParams, fmt.Sprintf("bus=%s", scsiCon.Bus))
+	}
+	if scsiCon.Addr != "" {
+		devParams = append(devParams, fmt.Sprintf("addr=%s", scsiCon.Addr))
+	}
+
+	qemuParams = append(qemuParams, "-device")
+	qemuParams = append(qemuParams, strings.Join(devParams, ","))
+
+	return qemuParams
+}
+
 // BridgeType is the type of the bridge
 type BridgeType uint
 

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -339,6 +339,20 @@ func TestVSOCKValid(t *testing.T) {
 	}
 }
 
+var deviceSCSIControllerStr = "-device virtio-scsi-pci,id=foo"
+var deviceSCSIControllerBusAddrStr = "-device virtio-scsi-pci,id=foo,bus=pci.0,addr=00:04.0"
+
+func TestAppendDeviceSCSIController(t *testing.T) {
+	scsiCon := SCSIController{
+		ID: "foo",
+	}
+	testAppend(scsiCon, deviceSCSIControllerStr, t)
+
+	scsiCon.Bus = "pci.0"
+	scsiCon.Addr = "00:04.0"
+	testAppend(scsiCon, deviceSCSIControllerBusAddrStr, t)
+}
+
 func TestAppendEmptyDevice(t *testing.T) {
 	device := SerialDevice{}
 


### PR DESCRIPTION
SCSI controller allows scsi disks to be attached on the SCSI
bus created by the controller.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>