### PR TITLE
Compute coverage statistics for unit tests in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ matrix:
 before_install:
   - go get github.com/alecthomas/gometalinter
   - gometalinter --install
+  - go get github.com/mattn/goveralls
 
 script:
    - go env
-   - go test -v ./...
+   - $GOPATH/bin/goveralls -v -service=travis-ci
    - gometalinter --tests --vendor --disable-all --enable=misspell --enable=vet --enable=ineffassign --enable=gofmt --enable=gocyclo --cyclo-over=15 --enable=golint --enable=errcheck --enable=deadcode ./...

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/intel/govmm)](https://goreportcard.com/report/github.com/intel/govmm)
 [![Build Status](https://travis-ci.org/intel/govmm.svg?branch=master)](https://travis-ci.org/intel/govmm)
 [![GoDoc](https://godoc.org/github.com/intel/govmm/qemu?status.svg)](https://godoc.org/github.com/intel/govmm/qemu)
+[![Coverage Status](https://coveralls.io/repos/github/intel/govmm/badge.svg?branch=master)](https://coveralls.io/github/intel/govmm?branch=master)
 
 Virtual Machine Manager for Go (govmm) is a suite of packages that
 provide Go APIs for creating and managing virtual machines.  There's


### PR DESCRIPTION
This commit enables unit test coverage computation in Travis CI builds.
Going forward, builds that decrease the unit test coverage by more than
1.0% will fail.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>