### PR TITLE
qemu: add extra options for the machine type

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -43,6 +43,10 @@ type Machine struct {
 
 	// Acceleration are the machine acceleration options to be used by qemu.
 	Acceleration string
+
+	// Options are options for the machine type
+	// For example gic-version=host and usb=off
+	Options string
 }
 
 // Device is the qemu device interface.
@@ -1238,6 +1242,10 @@ func (config *Config) appendMachine() {
 
 		if config.Machine.Acceleration != "" {
 			machineParams = append(machineParams, fmt.Sprintf(",accel=%s", config.Machine.Acceleration))
+		}
+
+		if config.Machine.Options != "" {
+			machineParams = append(machineParams, fmt.Sprintf(",%s", config.Machine.Options))
 		}
 
 		config.qemuParams = append(config.qemuParams, "-machine")

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -75,14 +75,20 @@ func testAppend(structure interface{}, expected string, t *testing.T) {
 	}
 }
 
-var machineString = "-machine pc-lite,accel=kvm,kernel_irqchip,nvdimm"
-
 func TestAppendMachine(t *testing.T) {
+	machineString := "-machine pc-lite,accel=kvm,kernel_irqchip,nvdimm"
 	machine := Machine{
 		Type:         "pc-lite",
 		Acceleration: "kvm,kernel_irqchip,nvdimm",
 	}
+	testAppend(machine, machineString, t)
 
+	machineString = "-machine pc-lite,accel=kvm,kernel_irqchip,nvdimm,gic-version=host,usb=off"
+	machine = Machine{
+		Type:         "pc-lite",
+		Acceleration: "kvm,kernel_irqchip,nvdimm",
+		Options:      "gic-version=host,usb=off",
+	}
 	testAppend(machine, machineString, t)
 }
 


### PR DESCRIPTION
certain machines types need to have extra options to enable or disable features
For example the machine type virt in certain hosts must have the gic version
(gic-version=3 or gic-version=host) to start without problems

Signed-off-by: Julio Montes <julio.montes@intel.com>