### PR TITLE
qemu: add DisableModern to SCSIController

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -838,6 +838,9 @@ type SCSIController struct {
 
 	// Addr is the PCI address offset, this is optional
 	Addr string
+
+	// DisableModern prevents qemu from relying on fast MMIO.
+	DisableModern bool
 }
 
 // Valid returns true if the SCSIController structure is valid and complete.
@@ -860,6 +863,9 @@ func (scsiCon SCSIController) QemuParams(config *Config) []string {
 	}
 	if scsiCon.Addr != "" {
 		devParams = append(devParams, fmt.Sprintf("addr=%s", scsiCon.Addr))
+	}
+	if scsiCon.DisableModern {
+		devParams = append(devParams, fmt.Sprintf("disable-modern=true"))
 	}
 
 	qemuParams = append(qemuParams, "-device")

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -346,7 +346,7 @@ func TestVSOCKValid(t *testing.T) {
 }
 
 var deviceSCSIControllerStr = "-device virtio-scsi-pci,id=foo"
-var deviceSCSIControllerBusAddrStr = "-device virtio-scsi-pci,id=foo,bus=pci.0,addr=00:04.0"
+var deviceSCSIControllerBusAddrStr = "-device virtio-scsi-pci,id=foo,bus=pci.0,addr=00:04.0,disable-modern=true"
 
 func TestAppendDeviceSCSIController(t *testing.T) {
 	scsiCon := SCSIController{
@@ -356,6 +356,7 @@ func TestAppendDeviceSCSIController(t *testing.T) {
 
 	scsiCon.Bus = "pci.0"
 	scsiCon.Addr = "00:04.0"
+	scsiCon.DisableModern = true
 	testAppend(scsiCon, deviceSCSIControllerBusAddrStr, t)
 }
 


### PR DESCRIPTION
DisableModern prevents qemu from relying on fast MMIO.

Signed-off-by: Julio Montes <julio.montes@intel.com>