### PR TITLE
Add rudimentary support for crosvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@
 
 Virtual Machine Manager for Go (govmm) is a suite of packages that
 provide Go APIs for creating and managing virtual machines.  There's
-currently support for only one hypervisor, qemu/kvm, support for which
-is provided by the github.com/intel/govmm/qemu package.
+currently support for two hypervisors; qemu/kvm and crosvm.
 
-The qemu package provides APIs for launching qemu instances and for
-managing those instances via QMP, once launched.  VM instances can
-be stopped, have devices attached to them and monitored for events
-via the qemu APIs.
+The github.com/intel/govmm/qemu package provides APIs for launching
+qemu instances and for managing those instances via QMP, once launched.
+VM instances can be stopped, have devices attached to them and monitored
+for events via the qemu APIs.
 
-The qemu package has no external dependencies apart from the Go
-standard library and so is nice and easy to vendor inside other
+The github.com/intel/govmm/crosvm package provides basic support for
+launching and stopping crosvm instances.
+
+The govmm packages have no external dependencies apart from the Go
+standard library and so are nice and easy to vendor inside other
 projects.

--- a/crosvm/control.go
+++ b/crosvm/control.go
@@ -1,0 +1,208 @@
+/*
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package crosvm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/intel/govmm/vmmlog"
+)
+
+// LaunchCustomCrosvm launches a crosvm guest using the parameters specified in the args
+// slice.  The attrs parameter can be used to control aspects of the newly created
+// crosvm process, such as the user and group under which it runs.  It may be nil.  If
+// missing, LaunchCustomCrosvm will search your path for the crosvm binary.    This function blocks
+// until the guest either fails to start or exits.
+func LaunchCustomCrosvm(ctx context.Context, path string, args []string,
+	attr *syscall.SysProcAttr, logger vmmlog.Log) error {
+	if logger == nil {
+		logger = vmmlog.NullLogger{}
+	}
+	args = append([]string{"run"}, args...)
+	return execCrosvm(ctx, path, args, attr, logger)
+}
+
+// LaunchCrosvm launches a crosvm guest using the parameters specified in the config
+// object.  The attrs parameter can be used to control aspects of the newly created
+// crosvm process, such as the user and group under which it runs.  It may be nil.
+// The path to the crosvm binary is specified in the config.Path field.  If missing,
+// LaunchCrosvm will search your path for the crosvm binary.  This function blocks
+// until the guest either fails to start or exits.
+func LaunchCrosvm(ctx context.Context, config Config, attr *syscall.SysProcAttr,
+	logger vmmlog.Log) error {
+	args, err := config.appendArgs(nil)
+	if err != nil {
+		return err
+	}
+
+	return LaunchCustomCrosvm(ctx, config.Path, args, attr, logger)
+}
+
+// LaunchCrosvmAsync launches a crosvm guest using the parameters specified in the
+// config object.  The function blocks until it has detected that the crosvm process
+// has successfully launched and the domain socket is open and ready to receive
+// commands.  As the function may return before the guest exits, it is not possible
+// to retrieve the exit status of the guest if it starts correctly.  Once this
+// function returns the ctx parameter cannot be used to stop the guest.  To
+// stop the guest, users will need to call ExecuteStop.
+// The parameters have the same names and meaning as LaunchCrosvm.
+func LaunchCrosvmAsync(ctx context.Context, config Config, attr *syscall.SysProcAttr,
+	logger vmmlog.Log) error {
+	if logger == nil {
+		logger = vmmlog.NullLogger{}
+	}
+
+	var launchErr error
+	localCtx, cancelFn := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func(ctx context.Context, errCh chan<- error) {
+		errCh <- LaunchCrosvm(ctx, config, nil, logger)
+	}(localCtx, errCh)
+
+	waitCompleteCh := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		select {
+		case launchErr = <-errCh:
+			cancelFn()
+		case <-ctx.Done():
+			cancelFn()
+		case <-waitCompleteCh:
+		}
+		wg.Done()
+	}()
+
+	logger.Infof("Waiting for guest to start")
+
+	err := WaitForGuest(localCtx, config.Socket, logger)
+	close(waitCompleteCh)
+	wg.Wait()
+	if launchErr != nil {
+		logger.Infof("Guest failed to launch: %v", launchErr)
+		return launchErr
+	}
+
+	if err != nil {
+		logger.Infof("Launch cancelled: %v", err)
+	}
+
+	return err
+}
+
+func execCrosvm(ctx context.Context, path string, args []string,
+	attr *syscall.SysProcAttr, logger vmmlog.Log) error {
+	if path == "" {
+		path = "crosvm"
+	}
+
+	logger.Infof("running %s %s", path, args)
+
+	cmd := exec.CommandContext(ctx, path, args...)
+	cmd.SysProcAttr = attr
+
+	return cmd.Run()
+}
+
+// ExecuteStop attempts to stop one or more crosvm guests.  The path to the crosvm
+// binary is specified in the config.Path field.  If missing, ExecuteStop will search
+// your path for the crosvm binary.  The domain sockets of the guests to be stopped are
+// provided in the sockets slice.  This function actually launches the crosvm binary
+// to stop the guests.  The attrs parameter can be used to control aspects
+// of this newly created crosvm process, such as the user and group under which it runs.
+// It may be nil.
+func ExecuteStop(ctx context.Context, path string, sockets []string,
+	attr *syscall.SysProcAttr, logger vmmlog.Log) error {
+	if len(sockets) == 0 {
+		return errors.New("Expected at least one socket path")
+	}
+
+	if logger == nil {
+		logger = vmmlog.NullLogger{}
+	}
+
+	args := append([]string{"stop"}, sockets...)
+	return execCrosvm(ctx, path, args, attr, logger)
+}
+
+// ExecuteBalloon attempts to adjust the balloon size of one or more crosvm guests by the
+// value specified in the numPages parameter.  The path to the crosvm binary is specified
+// in the config.Path field.  If missing, ExecuteBalloon will search your path for the crosvm
+// binary.  The domain sockets of the guests are provided in the sockets slice.
+// This function actually launches the crosvm binary to adjust the balloon size of the guests.
+// The attrs parameter can be used to control aspects of this newly created crosvm process,
+// such as the user and group under which it runs. It may be nil.
+func ExecuteBalloon(ctx context.Context, path string, numPages int32, sockets []string,
+	attr *syscall.SysProcAttr, logger vmmlog.Log) error {
+	if len(sockets) == 0 {
+		return errors.New("Expected at least one socket path")
+	}
+
+	if logger == nil {
+		logger = vmmlog.NullLogger{}
+	}
+
+	args := append([]string{"balloon", fmt.Sprintf("%d", numPages)}, sockets...)
+	return execCrosvm(ctx, path, args, attr, logger)
+}
+
+// WaitForGuest blocks until the VM identified by the path to a domain socket in the
+// path parameter has started or the ctx object is cancelled or times out.
+func WaitForGuest(ctx context.Context, path string, logger vmmlog.Log) error {
+	var conn net.Conn
+	var err error
+
+	if logger == nil {
+		logger = vmmlog.NullLogger{}
+	}
+
+	dialer := net.Dialer{}
+
+	for {
+		conn, err = dialer.DialContext(ctx, "unixgram", path)
+		if err == nil {
+			break
+		}
+
+		logger.Infof("Attempt to open guest socket failed %v", err)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Millisecond * 50):
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+		}
+
+		logger.Infof("Trying to open guest socket again")
+	}
+
+	logger.Infof("Successfully connected to guest socket")
+
+	_ = conn.Close()
+	return nil
+}

--- a/crosvm/crosvm.go
+++ b/crosvm/crosvm.go
@@ -1,0 +1,237 @@
+/*
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package crosvm
+
+import (
+	"errors"
+	"fmt"
+	"net"
+)
+
+// SMP is the multi processors configuration structure.
+type SMP struct {
+	// CPUs is the number of VCPUs made available to qemu.
+	CPUs uint
+}
+
+// Memory is the guest memory configuration structure.
+type Memory struct {
+	// Size is the amount of memory made available to the guest in MiB
+	Size uint
+}
+
+// Kernel is the guest kernel configuration structure.
+type Kernel struct {
+	// Path is the guest kernel path on the host filesystem.
+	Path string
+
+	// Params is the kernel parameters string.
+	Params string
+}
+
+// NetDevice represents a guest networking device
+type NetDevice struct {
+	// VHost enables virtio device emulation from the host kernel instead of from crosvm.
+	VHost bool
+
+	// MACAddress is the networking device interface MAC address.
+	MACAddress string
+
+	// IPv4 address to assign to the host TAP interface
+	HostIP net.IP
+
+	// Netmask for the subnet of the virtual machine
+	NetMask net.IPMask
+}
+
+// DiskType indicates that the type of a disk image
+type DiskType string
+
+const (
+	// FlatFile indicates that an image is a flat file
+	FlatFile DiskType = "flatfile"
+
+	// QCOW indicates that an image is a QCOW file
+	QCOW = "qcow"
+)
+
+// Disk represents a host disk image to be made accessible in the guest
+type Disk struct {
+	// Type provides the type of the disk image
+	Type DiskType
+
+	// Writeable indicates whether the image is writable or not
+	Writeable bool
+
+	// Path provides the path on the host to the disk image
+	Path string
+}
+
+// Security contains the security settings for the guest
+type Security struct {
+	// All devices run in a single non-sanboxed process
+	DisableSandbox bool
+
+	// Path on host to seccomp policy files
+	SeccompPolicyDir string
+}
+
+// Config is the crosvm configuration structure used to configure crosvm
+// virtual machine instances.
+type Config struct {
+	// Path is the crosvm binary path.
+	Path string
+
+	// RootFS is a path to a read-only root image
+	RootFS string
+
+	// Socket is a path to domain socket used to control the guest
+	Socket string
+
+	// Disks a slice of disks to attach to the guest
+	Disks []Disk
+
+	// Kernel is the guest kernel configuration.
+	Kernel Kernel
+
+	// Memory is the guest memory configuration.
+	Memory Memory
+
+	// SMP is the quest multi processors configuration.
+	SMP SMP
+
+	// Net specifies the networking configuration of the guest
+	Net NetDevice
+
+	// Sec specifies the security settings for the guest
+	Sec Security
+}
+
+func (s SMP) appendArgs(args []string) ([]string, error) {
+	if s.CPUs > 0 {
+		args = append(args, "-c", fmt.Sprintf("%d", s.CPUs))
+	}
+	return args, nil
+}
+
+func (m Memory) appendArgs(args []string) ([]string, error) {
+	if m.Size > 0 {
+		args = append(args, "-m", fmt.Sprintf("%d", m.Size))
+	}
+	return args, nil
+}
+
+// Must be the last function called when appending arguments
+func (k Kernel) appendArgs(args []string) ([]string, error) {
+	if k.Path == "" {
+		return nil, errors.New("Kernel path must be specified")
+	}
+
+	if k.Params != "" {
+		args = append(args, "-p", k.Params)
+	}
+
+	return append(args, k.Path), nil
+}
+
+func (n NetDevice) appendArgs(args []string) ([]string, error) {
+	if n.MACAddress == "" && len(n.HostIP) == 0 && len(n.NetMask) == 0 {
+		return args, nil
+	}
+
+	if n.MACAddress == "" || len(n.HostIP) == 0 || len(n.NetMask) == 0 {
+		return nil, errors.New("MACAddress, HostIP and NetMask must be defined")
+	}
+
+	args = append(args, "--mac", n.MACAddress)
+	args = append(args, "--host_ip", n.HostIP.String())
+	args = append(args, "--netmask", net.IP(n.NetMask).String())
+
+	if n.VHost {
+		args = append(args, "--vhost-net")
+	}
+
+	return args, nil
+}
+
+func (d Disk) appendArgs(args []string) ([]string, error) {
+	var opt string
+
+	if d.Path == "" {
+		return nil, errors.New("Path not specified for disk")
+	}
+
+	if d.Type == FlatFile {
+		opt = "disk"
+	} else if d.Type == QCOW {
+		opt = "qcow"
+	} else {
+		return nil, fmt.Errorf("Unknown disk type %s", d.Type)
+	}
+
+	if d.Writeable {
+		opt = "rw" + opt
+	}
+
+	return append(args, "--"+opt, d.Path), nil
+}
+
+func (c Security) appendArgs(args []string) ([]string, error) {
+	if c.DisableSandbox {
+		return append(args, "--disable-sandbox"), nil
+	}
+
+	return append(args, "-u", "--seccomp-policy-dir", c.SeccompPolicyDir), nil
+}
+
+func (c Config) appendArgs(args []string) ([]string, error) {
+	if c.RootFS == "" && len(c.Disks) == 0 {
+		return nil, errors.New("No rootfs or disks specified")
+	}
+
+	if c.Socket == "" {
+		return nil, errors.New("Socket path must be defined")
+	}
+	args = append(args, "-s", c.Socket)
+
+	if c.RootFS != "" {
+		args = append(args, "-r", c.RootFS)
+	}
+
+	var err error
+	for _, d := range c.Disks {
+		args, err = d.appendArgs(args)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, fn := range []func([]string) ([]string, error){
+		c.Net.appendArgs,
+		c.Memory.appendArgs,
+		c.SMP.appendArgs,
+		c.Sec.appendArgs,
+		c.Kernel.appendArgs, // order is important, kernel must be last
+	} {
+		args, err = fn(args)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return args, nil
+}

--- a/crosvm/crosvm_test.go
+++ b/crosvm/crosvm_test.go
@@ -1,0 +1,185 @@
+/*
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package crosvm
+
+import (
+	"net"
+	"reflect"
+	"testing"
+)
+
+func TestConfigGood(t *testing.T) {
+	cfg := Config{
+		RootFS: "crosvm/rootfs.ext4",
+		Socket: "/run/user/1000/crosvm.sock",
+		Kernel: Kernel{
+			Path:   "linux/arch/x86/boot/compressed/vmlinux.bin",
+			Params: "ip=192.168.30.2::192.168.30.1:255.255.255.0:crosvm:eth0",
+		},
+		Memory: Memory{
+			Size: 1024,
+		},
+		SMP: SMP{
+			CPUs: 2,
+		},
+		Net: NetDevice{
+			MACAddress: "AA:BB:CC:00:00:12",
+			HostIP:     net.ParseIP("192.168.30.1"),
+			NetMask:    net.IPv4Mask(255, 255, 255, 0),
+			VHost:      true,
+		},
+		Sec: Security{
+			DisableSandbox: true,
+		},
+	}
+
+	args, err := cfg.appendArgs(nil)
+	if err != nil {
+		t.Errorf("appendArgs failed: %v", err)
+	}
+
+	expected := []string{
+		"-s", "/run/user/1000/crosvm.sock",
+		"-r", "crosvm/rootfs.ext4",
+		"--mac", "AA:BB:CC:00:00:12",
+		"--host_ip", "192.168.30.1",
+		"--netmask", "255.255.255.0",
+		"--vhost-net",
+		"-m", "1024", "-c", "2",
+		"--disable-sandbox",
+		"-p", "ip=192.168.30.2::192.168.30.1:255.255.255.0:crosvm:eth0",
+		"linux/arch/x86/boot/compressed/vmlinux.bin",
+	}
+
+	if !reflect.DeepEqual(expected, args) {
+		t.Errorf("result of appendArgs does not match expected result")
+		t.Errorf("Got %v", args)
+		t.Errorf("Expected %v", expected)
+	}
+
+	// With security
+
+	cfg.Sec.DisableSandbox = false
+	cfg.Sec.SeccompPolicyDir = "secdir"
+
+	expected = []string{
+		"-s", "/run/user/1000/crosvm.sock",
+		"-r", "crosvm/rootfs.ext4",
+		"--mac", "AA:BB:CC:00:00:12",
+		"--host_ip", "192.168.30.1",
+		"--netmask", "255.255.255.0",
+		"--vhost-net",
+		"-m", "1024", "-c", "2",
+		"-u", "--seccomp-policy-dir", "secdir",
+		"-p", "ip=192.168.30.2::192.168.30.1:255.255.255.0:crosvm:eth0",
+		"linux/arch/x86/boot/compressed/vmlinux.bin",
+	}
+
+	args, err = cfg.appendArgs(nil)
+	if err != nil {
+		t.Errorf("appendArgs failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(expected, args) {
+		t.Errorf("result of appendArgs does not match expected result")
+		t.Errorf("Got %v", args)
+		t.Errorf("Expected %v", expected)
+	}
+
+	// With Disks but without network, mem or CPU
+
+	cfg.Net = NetDevice{}
+	cfg.Memory = Memory{}
+	cfg.SMP = SMP{}
+	cfg.Disks = []Disk{
+		{
+			Type:      QCOW,
+			Writeable: true,
+			Path:      "image.qcow",
+		},
+		{
+			Type:      FlatFile,
+			Writeable: false,
+			Path:      "image.ext4",
+		},
+	}
+
+	args, err = cfg.appendArgs(nil)
+	if err != nil {
+		t.Errorf("appendArgs failed: %v", err)
+	}
+
+	expected = []string{
+		"-s", "/run/user/1000/crosvm.sock",
+		"-r", "crosvm/rootfs.ext4",
+		"--rwqcow", "image.qcow",
+		"--disk", "image.ext4",
+		"-u", "--seccomp-policy-dir", "secdir",
+		"-p", "ip=192.168.30.2::192.168.30.1:255.255.255.0:crosvm:eth0",
+		"linux/arch/x86/boot/compressed/vmlinux.bin",
+	}
+
+	if !reflect.DeepEqual(expected, args) {
+		t.Errorf("result of appendArgs does not match expected result")
+		t.Errorf("Got %v", args)
+		t.Errorf("Expected %v", expected)
+	}
+}
+
+func TestConfigBad(t *testing.T) {
+	cfg := Config{}
+
+	_, err := cfg.appendArgs(nil)
+	if err == nil {
+		t.Errorf("appendArgs on an empty config expected to fail")
+	}
+
+	minimalCfg := Config{
+		RootFS: "crosvm/rootfs.ext4",
+		Socket: "/run/user/1000/crosvm.sock",
+		Kernel: Kernel{
+			Path: "linux/arch/x86/boot/compressed/vmlinux.bin",
+		},
+	}
+
+	_, err = minimalCfg.appendArgs(nil)
+	if err != nil {
+		t.Errorf("appendArgs on minimal config failed: %v", err)
+	}
+
+	cfg = minimalCfg
+	cfg.Disks = []Disk{
+		{
+			Type:      QCOW,
+			Writeable: true,
+		},
+	}
+	_, err = cfg.appendArgs(nil)
+	if err == nil {
+		t.Errorf("appendArgs on a config with missing disk path expected to fail")
+	}
+
+	cfg = minimalCfg
+	cfg.Net = NetDevice{
+		MACAddress: "AA:BB:CC:00:00:12",
+		NetMask:    net.IPv4Mask(255, 255, 255, 0),
+	}
+	_, err = cfg.appendArgs(nil)
+	if err == nil {
+		t.Errorf("appendArgs on a config with missing HostIP expected to fail")
+	}
+}

--- a/crosvm/example_test.go
+++ b/crosvm/example_test.go
@@ -1,0 +1,100 @@
+/*
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package crosvm_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/user"
+	"path/filepath"
+	"time"
+
+	"github.com/intel/govmm/crosvm"
+)
+
+type StderrLogger struct{}
+
+func (l StderrLogger) V(level int32) bool {
+	return true
+}
+
+func (l StderrLogger) Infof(format string, v ...interface{}) {
+	fmt.Fprintf(os.Stderr, format, v...)
+	fmt.Fprintln(os.Stderr, "")
+}
+
+func (l StderrLogger) Warningf(format string, v ...interface{}) {
+	fmt.Fprintf(os.Stderr, format, v...)
+	fmt.Fprintln(os.Stderr, "")
+}
+
+func (l StderrLogger) Errorf(format string, v ...interface{}) {
+	fmt.Fprintf(os.Stderr, format, v...)
+	fmt.Fprintln(os.Stderr, "")
+}
+
+func Example() {
+	socket := fmt.Sprintf("/run/user/%d/crosvm.sock", os.Getuid())
+	user, err := user.Current()
+	if err != nil {
+		panic(err)
+	}
+
+	cfg := crosvm.Config{
+		RootFS: filepath.Join(user.HomeDir, "crosvm/rootfs.ext4"),
+		Socket: socket,
+		Kernel: crosvm.Kernel{
+			Path:   filepath.Join(user.HomeDir, "linux/arch/x86/boot/compressed/vmlinux.bin"),
+			Params: "ip=192.168.30.2::192.168.30.1:255.255.255.0:crosvm:eth0",
+		},
+		Net: crosvm.NetDevice{
+			MACAddress: "AA:BB:CC:00:00:12",
+			HostIP:     net.ParseIP("192.168.30.1"),
+			NetMask:    net.IPv4Mask(255, 255, 255, 0),
+		},
+		Sec: crosvm.Security{
+			DisableSandbox: true,
+		},
+	}
+
+	logger := StderrLogger{}
+	err = crosvm.LaunchCrosvmAsync(context.Background(), cfg, nil, logger)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Fprintln(os.Stderr, "Crosvm guest running.")
+
+	fmt.Fprintln(os.Stderr, "Adjusting balloon size of guest by 64 pages")
+	err = crosvm.ExecuteBalloon(context.Background(), "", 64, []string{socket},
+		nil, logger)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to adjust balloon size of guest")
+	}
+
+	fmt.Fprintln(os.Stderr, "Wait for 10 seconds")
+
+	<-time.After(time.Second * 10)
+
+	err = crosvm.ExecuteStop(context.Background(), "", []string{socket}, nil,
+		logger)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to stop crosvm guest")
+	}
+}

--- a/vmmlog/vmmlog.go
+++ b/vmmlog/vmmlog.go
@@ -1,0 +1,61 @@
+/*
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package vmmlog
+
+// Log is a logging interface used by the govmm package to log various
+// interesting pieces of information.  Rather than introduce a dependency
+// on a given logging package, govmm presents this interface that allows
+// clients to provide their own logging type which they can use to
+// seamlessly integrate govmm's logs into their own logs.
+type Log interface {
+	// V returns true if the given argument is less than or equal
+	// to the implementation's defined verbosity level.
+	V(int32) bool
+
+	// Infof writes informational output to the log.  A newline will be
+	// added to the output if one is not provided.
+	Infof(string, ...interface{})
+
+	// Warningf writes warning output to the log.  A newline will be
+	// added to the output if one is not provided.
+	Warningf(string, ...interface{})
+
+	// Errorf writes error output to the log.  A newline will be
+	// added to the output if one is not provided.
+	Errorf(string, ...interface{})
+}
+
+// NullLogger provides an implementation of the Log interface that discards
+// all logs.
+type NullLogger struct{}
+
+// V logs nothing.
+func (l NullLogger) V(level int32) bool {
+	return false
+}
+
+// Infof logs nothing
+func (l NullLogger) Infof(format string, v ...interface{}) {
+}
+
+// Warningf logs nothing
+func (l NullLogger) Warningf(format string, v ...interface{}) {
+}
+
+// Errorf logs nothing
+func (l NullLogger) Errorf(format string, v ...interface{}) {
+}


### PR DESCRIPTION
This PR adds two new packages

- github.com/intel/govmm/vmmlog
- github.com/intel/govmm/crosvm

vmmlog provides an abstract logging interface that can be used by other packages in the govmm repo.  Currently, it's only used by the crosvm package but soon the qemu package will be modified to use it as well.

crosvm provides a set of data structures and methods for launching and manipulating crosvm guests.  The API support by crosvm is fairly limited and simple, when compared to qemu, so this package provides fewer features than the corresponding qemu package.

The PR makes no changes to the qemu package and so shouldn't affect any existing govmm clients.