### PR TITLE
Add ability to associate a SCSI controller device with an iothread

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -841,6 +841,9 @@ type SCSIController struct {
 
 	// DisableModern prevents qemu from relying on fast MMIO.
 	DisableModern bool
+
+	// IOThread is the IO thread on which IO will be handled
+	IOThread string
 }
 
 // Valid returns true if the SCSIController structure is valid and complete.
@@ -866,6 +869,9 @@ func (scsiCon SCSIController) QemuParams(config *Config) []string {
 	}
 	if scsiCon.DisableModern {
 		devParams = append(devParams, fmt.Sprintf("disable-modern=true"))
+	}
+	if scsiCon.IOThread != "" {
+		devParams = append(devParams, fmt.Sprintf("iothread=%s", scsiCon.IOThread))
 	}
 
 	qemuParams = append(qemuParams, "-device")

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -350,7 +350,7 @@ func TestVSOCKValid(t *testing.T) {
 }
 
 var deviceSCSIControllerStr = "-device virtio-scsi-pci,id=foo"
-var deviceSCSIControllerBusAddrStr = "-device virtio-scsi-pci,id=foo,bus=pci.0,addr=00:04.0,disable-modern=true"
+var deviceSCSIControllerBusAddrStr = "-device virtio-scsi-pci,id=foo,bus=pci.0,addr=00:04.0,disable-modern=true,iothread=iothread1"
 
 func TestAppendDeviceSCSIController(t *testing.T) {
 	scsiCon := SCSIController{
@@ -361,6 +361,7 @@ func TestAppendDeviceSCSIController(t *testing.T) {
 	scsiCon.Bus = "pci.0"
 	scsiCon.Addr = "00:04.0"
 	scsiCon.DisableModern = true
+	scsiCon.IOThread = "iothread1"
 	testAppend(scsiCon, deviceSCSIControllerBusAddrStr, t)
 }
 

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -67,6 +67,10 @@ func testAppend(structure interface{}, expected string, t *testing.T) {
 	case RTC:
 		config.RTC = s
 		config.appendRTC()
+
+	case IOThread:
+		config.IOThreads = []IOThread{s}
+		config.appendIOThreads()
 	}
 
 	result := strings.Join(config.qemuParams, " ")
@@ -524,4 +528,14 @@ func TestAppendRTC(t *testing.T) {
 	}
 
 	testAppend(rtc, rtcString, t)
+}
+
+var ioThreadString = "-object iothread,id=iothread1"
+
+func TestAppendIOThread(t *testing.T) {
+	ioThread := IOThread{
+		ID: "iothread1",
+	}
+
+	testAppend(ioThread, ioThreadString, t)
 }


### PR DESCRIPTION
IOThreads allow IO to be handled on a separate thread rather than the main event loop. This has a positive impact on performance in terms of throughput and latency.