### PR TITLE
Add APIs to enable vm templating

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -1468,23 +1468,7 @@ func (config *Config) appendKernel() {
 	}
 }
 
-func (config *Config) appendKnobs() {
-	if config.Knobs.NoUserConfig == true {
-		config.qemuParams = append(config.qemuParams, "-no-user-config")
-	}
-
-	if config.Knobs.NoDefaults == true {
-		config.qemuParams = append(config.qemuParams, "-nodefaults")
-	}
-
-	if config.Knobs.NoGraphic == true {
-		config.qemuParams = append(config.qemuParams, "-nographic")
-	}
-
-	if config.Knobs.Daemonize == true {
-		config.qemuParams = append(config.qemuParams, "-daemonize")
-	}
-
+func (config *Config) appendMemoryKnobs() {
 	if config.Knobs.HugePages == true {
 		if config.Memory.Size != "" {
 			dimmName := "dimm1"
@@ -1525,6 +1509,26 @@ func (config *Config) appendKnobs() {
 			config.qemuParams = append(config.qemuParams, numaMemParam)
 		}
 	}
+}
+
+func (config *Config) appendKnobs() {
+	if config.Knobs.NoUserConfig == true {
+		config.qemuParams = append(config.qemuParams, "-no-user-config")
+	}
+
+	if config.Knobs.NoDefaults == true {
+		config.qemuParams = append(config.qemuParams, "-nodefaults")
+	}
+
+	if config.Knobs.NoGraphic == true {
+		config.qemuParams = append(config.qemuParams, "-nographic")
+	}
+
+	if config.Knobs.Daemonize == true {
+		config.qemuParams = append(config.qemuParams, "-daemonize")
+	}
+
+	config.appendMemoryKnobs()
 
 	if config.Knobs.Realtime == true {
 		config.qemuParams = append(config.qemuParams, "-realtime")

--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -1182,6 +1182,9 @@ type Knobs struct {
 	// Only active when Realtime is set to true
 	Mlock bool
 
+	// Stopped will not start guest CPU at startup
+	Stopped bool
+
 	// Realtime will enable realtime QEMU
 	Realtime bool
 }
@@ -1520,6 +1523,10 @@ func (config *Config) appendKnobs() {
 			config.qemuParams = append(config.qemuParams, "-realtime")
 			config.qemuParams = append(config.qemuParams, "mlock=off")
 		}
+	}
+
+	if config.Knobs.Stopped == true {
+		config.qemuParams = append(config.qemuParams, "-S")
 	}
 }
 

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -390,13 +390,15 @@ func TestAppendEmptyDevice(t *testing.T) {
 func TestAppendKnobsAllTrue(t *testing.T) {
 	var knobsString = "-no-user-config -nodefaults -nographic -daemonize -realtime mlock=on"
 	knobs := Knobs{
-		NoUserConfig: true,
-		NoDefaults:   true,
-		NoGraphic:    true,
-		Daemonize:    true,
-		MemPrealloc:  true,
-		Realtime:     true,
-		Mlock:        true,
+		NoUserConfig:        true,
+		NoDefaults:          true,
+		NoGraphic:           true,
+		Daemonize:           true,
+		MemPrealloc:         true,
+		FileBackedMem:       true,
+		FileBackedMemShared: true,
+		Realtime:            true,
+		Mlock:               true,
 	}
 
 	testAppend(knobs, knobsString, t)
@@ -405,12 +407,14 @@ func TestAppendKnobsAllTrue(t *testing.T) {
 func TestAppendKnobsAllFalse(t *testing.T) {
 	var knobsString = "-realtime mlock=off"
 	knobs := Knobs{
-		NoUserConfig: false,
-		NoDefaults:   false,
-		NoGraphic:    false,
-		MemPrealloc:  false,
-		Realtime:     false,
-		Mlock:        false,
+		NoUserConfig:        false,
+		NoDefaults:          false,
+		NoGraphic:           false,
+		MemPrealloc:         false,
+		FileBackedMem:       false,
+		FileBackedMemShared: false,
+		Realtime:            false,
+		Mlock:               false,
 	}
 
 	testAppend(knobs, knobsString, t)
@@ -435,6 +439,7 @@ func TestAppendMemory(t *testing.T) {
 		Size:   "2G",
 		Slots:  2,
 		MaxMem: "3G",
+		Path:   "",
 	}
 
 	testAppend(memory, memoryString, t)

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -388,7 +388,7 @@ func TestAppendEmptyDevice(t *testing.T) {
 }
 
 func TestAppendKnobsAllTrue(t *testing.T) {
-	var knobsString = "-no-user-config -nodefaults -nographic -daemonize -realtime mlock=on"
+	var knobsString = "-no-user-config -nodefaults -nographic -daemonize -realtime mlock=on -S"
 	knobs := Knobs{
 		NoUserConfig:        true,
 		NoDefaults:          true,
@@ -399,6 +399,7 @@ func TestAppendKnobsAllTrue(t *testing.T) {
 		FileBackedMemShared: true,
 		Realtime:            true,
 		Mlock:               true,
+		Stopped:             true,
 	}
 
 	testAppend(knobs, knobsString, t)
@@ -415,6 +416,7 @@ func TestAppendKnobsAllFalse(t *testing.T) {
 		FileBackedMemShared: false,
 		Realtime:            false,
 		Mlock:               false,
+		Stopped:             false,
 	}
 
 	testAppend(knobs, knobsString, t)

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -71,6 +71,9 @@ func testAppend(structure interface{}, expected string, t *testing.T) {
 	case IOThread:
 		config.IOThreads = []IOThread{s}
 		config.appendIOThreads()
+	case Incoming:
+		config.Incoming = s
+		config.appendIncoming()
 	}
 
 	result := strings.Join(config.qemuParams, " ")
@@ -562,4 +565,26 @@ func TestAppendIOThread(t *testing.T) {
 	}
 
 	testAppend(ioThread, ioThreadString, t)
+}
+
+var incomingStringFD = "-S -incoming fd:3"
+
+func TestAppendIncomingFD(t *testing.T) {
+	source := Incoming{
+		MigrationType: MigrationFD,
+		FD:            os.Stdout,
+	}
+
+	testAppend(source, incomingStringFD, t)
+}
+
+var incomingStringExec = "-S -incoming exec:test migration cmd"
+
+func TestAppendIncomingExec(t *testing.T) {
+	source := Incoming{
+		MigrationType: MigrationExec,
+		Exec:          "test migration cmd",
+	}
+
+	testAppend(source, incomingStringExec, t)
 }

--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -837,3 +837,12 @@ func (q *QMP) ExecSetMigrationCaps(ctx context.Context, caps []map[string]interf
 
 	return q.executeCommand(ctx, "migrate-set-capabilities", args, nil)
 }
+
+// ExecSetMigrateArguments sets the command line used for migration
+func (q *QMP) ExecSetMigrateArguments(ctx context.Context, url string) error {
+	args := map[string]interface{}{
+		"uri": url,
+	}
+
+	return q.executeCommand(ctx, "migrate", args, nil)
+}

--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -828,3 +828,12 @@ func (q *QMP) ExecuteQueryHotpluggableCPUs(ctx context.Context) ([]HotpluggableC
 
 	return cpus, nil
 }
+
+// ExecSetMigrationCaps sets migration capabilities
+func (q *QMP) ExecSetMigrationCaps(ctx context.Context, caps []map[string]interface{}) error {
+	args := map[string]interface{}{
+		"capabilities": caps,
+	}
+
+	return q.executeCommand(ctx, "migrate-set-capabilities", args, nil)
+}

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -910,3 +910,20 @@ func TestExecSetMigrationCaps(t *testing.T) {
 	q.Shutdown()
 	<-disconnectedCh
 }
+
+// Checks that migrate arguments can be set
+func TestExecSetMigrateArguments(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommand("migrate", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	err := q.ExecSetMigrateArguments(context.Background(), "exec:foobar")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v\n", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+}

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -887,3 +887,26 @@ func TestQMPExecuteQueryHotpluggableCPUs(t *testing.T) {
 	q.Shutdown()
 	<-disconnectedCh
 }
+
+// Checks that migrate capabilities can be set
+func TestExecSetMigrationCaps(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommand("migrate-set-capabilities", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	caps := []map[string]interface{}{
+		{
+			"capability": "bypass-shared-memory",
+			"state":      true,
+		},
+	}
+	err := q.ExecSetMigrationCaps(context.Background(), caps)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v\n", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+}

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -927,3 +927,21 @@ func TestExecSetMigrateArguments(t *testing.T) {
 	q.Shutdown()
 	<-disconnectedCh
 }
+
+// Checks hotplug memory
+func TestExecHotplugMemory(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommand("object-add", nil, "return", nil)
+	buf.AddCommand("device_add", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	err := q.ExecHotplugMemory(context.Background(), "memory-backend-ram", "mem0", "", 128)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v\n", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+}


### PR DESCRIPTION
The PR adds necessary qemu config and APIs that help to enable the vm templating feature:
- a memory device path
- a boolean that controls if file backed memory is enabled
- a boolean that controls if file backed memory is shared
- Incoming structure that allows to set migration exec command line
- QMP migrate-set-capabilities that sets migration bypass-shared-memory capability
- QMP migrate that sets migration arguments
- QMP hotplug memory

related: kata-containers/runtime/pull/303

VM templating leverages qemu live migration and qemu's ability to use shared memory backend on the same host. The following graph shows the process of creating a template VM and creating new VMs based on it.

![VM template](https://github.com/bergwolf/raw-contents/blob/master/kata/vm-templating.jpeg?raw=true)
