### PR TITLE
qemu/qmp: implement function to hotplug vsock-pci

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -82,6 +82,9 @@ const (
 
 	// VirtioSerialPort is the serial port device driver.
 	VirtioSerialPort = "virtserialport"
+
+	// VHostVSockPCI is the vhost vsock pci driver.
+	VHostVSockPCI = "vhost-vsock-pci"
 )
 
 // ObjectType is a string representing a qemu object type.

--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -881,3 +881,13 @@ func (q *QMP) ExecHotplugMemory(ctx context.Context, qomtype, id, mempath string
 
 	return err
 }
+
+// ExecutePCIVSockAdd adds a vhost-vsock-pci bus
+func (q *QMP) ExecutePCIVSockAdd(ctx context.Context, id, guestCID string) error {
+	args := map[string]interface{}{
+		"driver":    VHostVSockPCI,
+		"id":        id,
+		"guest-cid": guestCID,
+	}
+	return q.executeCommand(ctx, "device_add", args, nil)
+}

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -945,3 +945,20 @@ func TestExecHotplugMemory(t *testing.T) {
 	q.Shutdown()
 	<-disconnectedCh
 }
+
+// Checks vsock-pci hotplug
+func TestExecutePCIVSockAdd(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommand("device_add", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	err := q.ExecutePCIVSockAdd(context.Background(), "vsock-pci0", "3")
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+}


### PR DESCRIPTION
Implement function to hotplug vsocks,	vsocks are needed
to communicate processes are running inside the VM
with processes are running on the host.

Signed-off-by: Julio Montes <julio.montes@intel.com>