### PR TITLE
qemu: add vhostfd and disable-modern to vsock hotplug

### DIFF
--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -883,11 +883,17 @@ func (q *QMP) ExecHotplugMemory(ctx context.Context, qomtype, id, mempath string
 }
 
 // ExecutePCIVSockAdd adds a vhost-vsock-pci bus
-func (q *QMP) ExecutePCIVSockAdd(ctx context.Context, id, guestCID string) error {
+func (q *QMP) ExecutePCIVSockAdd(ctx context.Context, id, guestCID, vhostfd string, disableModern bool) error {
 	args := map[string]interface{}{
 		"driver":    VHostVSockPCI,
 		"id":        id,
 		"guest-cid": guestCID,
+		"vhostfd":   vhostfd,
 	}
+
+	if disableModern {
+		args["disable-modern"] = disableModern
+	}
+
 	return q.executeCommand(ctx, "device_add", args, nil)
 }

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -955,7 +955,7 @@ func TestExecutePCIVSockAdd(t *testing.T) {
 	cfg := QMPConfig{Logger: qmpTestLogger{}}
 	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
 	checkVersion(t, connectedCh)
-	err := q.ExecutePCIVSockAdd(context.Background(), "vsock-pci0", "3")
+	err := q.ExecutePCIVSockAdd(context.Background(), "vsock-pci0", "3", "1", true)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"reflect"
 	"sync"
 	"testing"
@@ -956,6 +957,23 @@ func TestExecutePCIVSockAdd(t *testing.T) {
 	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
 	checkVersion(t, connectedCh)
 	err := q.ExecutePCIVSockAdd(context.Background(), "vsock-pci0", "3", "1", true)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+}
+
+// Checks getfd
+func TestExecuteGetFdD(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommand("getfd", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	err := q.ExecuteGetFD(context.Background(), "foo", os.NewFile(0, "foo"))
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}


### PR DESCRIPTION
`vhostfd` is used to specify the vhost-vsock device fd, and it holds
the context ID previously opened.

`disable-modern` is to disable the use of "modern" devices, it's used
to make azure VMs happy.

Signed-off-by: Julio Montes <julio.montes@intel.com>