### PR TITLE
qemu: add vhostfd and disable-modern to vhost-vsock-pci

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -965,6 +965,12 @@ type VSOCKDevice struct {
 	ID string
 
 	ContextID uint32
+
+	// VHostFD vhost file descriptor that holds the ContextID
+	VHostFD *os.File
+
+	// DisableModern prevents qemu from relying on fast MMIO.
+	DisableModern bool
 }
 
 const (
@@ -989,12 +995,22 @@ func (vsock VSOCKDevice) Valid() bool {
 
 // QemuParams returns the qemu parameters built out of the VSOCK device.
 func (vsock VSOCKDevice) QemuParams(config *Config) []string {
+	var deviceParams []string
 	var qemuParams []string
 
-	deviceParam := fmt.Sprintf("%s,id=%s,%s=%d", VhostVSOCKPCI, vsock.ID, VSOCKGuestCID, vsock.ContextID)
+	deviceParams = append(deviceParams, fmt.Sprintf("%s", VhostVSOCKPCI))
+	if vsock.DisableModern {
+		deviceParams = append(deviceParams, ",disable-modern=true")
+	}
+	if vsock.VHostFD != nil {
+		qemuFDs := config.appendFDs([]*os.File{vsock.VHostFD})
+		deviceParams = append(deviceParams, fmt.Sprintf(",vhostfd=%d", qemuFDs[0]))
+	}
+	deviceParams = append(deviceParams, fmt.Sprintf(",id=%s", vsock.ID))
+	deviceParams = append(deviceParams, fmt.Sprintf(",%s=%d", VSOCKGuestCID, vsock.ContextID))
 
 	qemuParams = append(qemuParams, "-device")
-	qemuParams = append(qemuParams, deviceParam)
+	qemuParams = append(qemuParams, strings.Join(deviceParams, ""))
 
 	return qemuParams
 }

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -329,12 +329,14 @@ func TestAppendDeviceVFIO(t *testing.T) {
 	testAppend(vfioDevice, deviceVFIOString, t)
 }
 
-var deviceVSOCKString = "-device vhost-vsock-pci,id=vhost-vsock-pci0,guest-cid=4"
+var deviceVSOCKString = "-device vhost-vsock-pci,disable-modern=true,id=vhost-vsock-pci0,guest-cid=4"
 
 func TestAppendVSOCK(t *testing.T) {
 	vsockDevice := VSOCKDevice{
-		ID:        "vhost-vsock-pci0",
-		ContextID: 4,
+		ID:            "vhost-vsock-pci0",
+		ContextID:     4,
+		VHostFD:       nil,
+		DisableModern: true,
 	}
 
 	testAppend(vsockDevice, deviceVSOCKString, t)
@@ -342,8 +344,10 @@ func TestAppendVSOCK(t *testing.T) {
 
 func TestVSOCKValid(t *testing.T) {
 	vsockDevice := VSOCKDevice{
-		ID:        "vhost-vsock-pci0",
-		ContextID: MinimalGuestCID - 1,
+		ID:            "vhost-vsock-pci0",
+		ContextID:     MinimalGuestCID - 1,
+		VHostFD:       nil,
+		DisableModern: true,
 	}
 
 	if vsockDevice.Valid() {


### PR DESCRIPTION
`vhostfd` is the vhost file descriptor that holds the socket context ID
`disable-modern` prevents qemu from relying on fast MMIO

Signed-off-by: Julio Montes <julio.montes@intel.com>