### PR TITLE
qemu/qmp: implement functions to hotplug chardevs and serial ports

### DIFF
--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -986,3 +986,17 @@ func (q *QMP) ExecuteCharDevUnixSocketAdd(ctx context.Context, id, path string, 
 	}
 	return q.executeCommand(ctx, "chardev-add", args, nil)
 }
+
+// ExecuteVirtSerialPortAdd adds a virtserialport.
+// id is an identifier for the virtserialport, name is a name for the virtserialport and
+// it will be visible in the VM, chardev is the character device id previously added.
+func (q *QMP) ExecuteVirtSerialPortAdd(ctx context.Context, id, name, chardev string) error {
+	args := map[string]interface{}{
+		"driver":  VirtioSerialPort,
+		"id":      id,
+		"name":    name,
+		"chardev": chardev,
+	}
+
+	return q.executeCommand(ctx, "device_add", args, nil)
+}

--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -963,3 +963,26 @@ func (q *QMP) ExecuteGetFD(ctx context.Context, fdname string, fd *os.File) erro
 	_, err := q.executeCommandWithResponse(ctx, "getfd", args, oob, nil)
 	return err
 }
+
+// ExecuteCharDevUnixSocketAdd adds a character device using as backend a unix socket,
+// id is an identifier for the device, path specifies the local path of the unix socket,
+// wait is to block waiting for a client to connect, server specifies that the socket is a listening socket.
+func (q *QMP) ExecuteCharDevUnixSocketAdd(ctx context.Context, id, path string, wait, server bool) error {
+	args := map[string]interface{}{
+		"id": id,
+		"backend": map[string]interface{}{
+			"type": "socket",
+			"data": map[string]interface{}{
+				"wait":   wait,
+				"server": server,
+				"addr": map[string]interface{}{
+					"type": "unix",
+					"data": map[string]interface{}{
+						"path": path,
+					},
+				},
+			},
+		},
+	}
+	return q.executeCommand(ctx, "chardev-add", args, nil)
+}

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -1040,3 +1040,20 @@ func TestExecuteGetFdD(t *testing.T) {
 	q.Shutdown()
 	<-disconnectedCh
 }
+
+// Checks chardev-add unix socket
+func TestExecuteCharDevUnixSocketAdd(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommand("chardev-add", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	err := q.ExecuteCharDevUnixSocketAdd(context.Background(), "foo", "foo.sock", false, true)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+}

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -1057,3 +1057,20 @@ func TestExecuteCharDevUnixSocketAdd(t *testing.T) {
 	q.Shutdown()
 	<-disconnectedCh
 }
+
+// Checks virtio serial port hotplug
+func TestExecuteVirtSerialPortAdd(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommand("device_add", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	err := q.ExecuteVirtSerialPortAdd(context.Background(), "foo", "foo.channel", "foo")
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+}


### PR DESCRIPTION
Implement function to hotplug virtio serial ports, the serial ports
are visible in the guest at the directory /dev/virtio-ports.

implement function to hotplug character devices using as backend
unix sockets, binding a character device with a serial port allows
the communnication between processes running in the guest with
processes running in the host.