### PR TITLE
qemu/qmp: add addr and bus to hotplug vsock devices

### DIFF
--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -938,12 +938,17 @@ func (q *QMP) ExecHotplugMemory(ctx context.Context, qomtype, id, mempath string
 }
 
 // ExecutePCIVSockAdd adds a vhost-vsock-pci bus
-func (q *QMP) ExecutePCIVSockAdd(ctx context.Context, id, guestCID, vhostfd string, disableModern bool) error {
+func (q *QMP) ExecutePCIVSockAdd(ctx context.Context, id, guestCID, vhostfd, addr, bus string, disableModern bool) error {
 	args := map[string]interface{}{
 		"driver":    VHostVSockPCI,
 		"id":        id,
 		"guest-cid": guestCID,
 		"vhostfd":   vhostfd,
+		"addr":      addr,
+	}
+
+	if bus != "" {
+		args["bus"] = bus
 	}
 
 	if disableModern {

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -1016,7 +1016,7 @@ func TestExecutePCIVSockAdd(t *testing.T) {
 	cfg := QMPConfig{Logger: qmpTestLogger{}}
 	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
 	checkVersion(t, connectedCh)
-	err := q.ExecutePCIVSockAdd(context.Background(), "vsock-pci0", "3", "1", true)
+	err := q.ExecutePCIVSockAdd(context.Background(), "vsock-pci0", "3", "1", "1", "1", true)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}


### PR DESCRIPTION
For machines types based on PCIe like q35, device addr and bus must be specified.
For machines types based on PCI like pc, device addr must be specified and bus
is optional since devices can be hot plugged directly on the root bus.

Signed-off-by: Julio Montes <julio.montes@intel.com>