### PR TITLE
qemu: Do not try and generate invalid RTC parameters

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -1064,16 +1064,12 @@ type RTC struct {
 
 // Valid returns true if the RTC structure is valid and complete.
 func (rtc RTC) Valid() bool {
-	if rtc.Clock != "" {
-		if rtc.Clock != Host && rtc.Clock != VM {
-			return false
-		}
+	if rtc.Clock != Host && rtc.Clock != VM {
+		return false
 	}
 
-	if rtc.DriftFix != "" {
-		if rtc.DriftFix != Slew && rtc.DriftFix != NoDriftFix {
-			return false
-		}
+	if rtc.DriftFix != Slew && rtc.DriftFix != NoDriftFix {
+		return false
 	}
 
 	return true


### PR DESCRIPTION
If no RTC is specified in the config then do not generate any RTC command line
options. RTC command line options are optional for QEMU so make Valid() return
false when presented with the empty version of the RTC struct containing empty
strings.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>