### PR TITLE
qemu/qmp: support hotplug a nic whose qdisc is mq

### DIFF
--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -439,7 +439,7 @@ func TestQMPNetPCIDeviceAdd(t *testing.T) {
 	cfg := QMPConfig{Logger: qmpTestLogger{}}
 	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
 	checkVersion(t, connectedCh)
-	err := q.ExecuteNetPCIDeviceAdd(context.Background(), "br0", "virtio-0", "02:42:ac:11:00:02", "0x7", "")
+	err := q.ExecuteNetPCIDeviceAdd(context.Background(), "br0", "virtio-0", "02:42:ac:11:00:02", "0x7", "", 8)
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}


### PR DESCRIPTION
If we hotplug a nic with args mq=on, its qdisc will be mq by default.
This aligns with cold plug nics.

Signed-off-by: Ruidong Cao <caoruidong@huawei.com>