### PR TITLE
qemu: skip setting system memory if it is set via dimm device

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -1502,13 +1502,13 @@ func (config *Config) appendMemoryKnobs() {
 		if config.Memory.Size != "" {
 			dimmName := "dimm1"
 			objMemParam := "memory-backend-ram,id=" + dimmName + ",size=" + config.Memory.Size + ",prealloc=on"
-			deviceMemParam := "pc-dimm,id=" + dimmName + ",memdev=" + dimmName
+			numaMemParam := "node,memdev=" + dimmName
 
 			config.qemuParams = append(config.qemuParams, "-object")
 			config.qemuParams = append(config.qemuParams, objMemParam)
 
-			config.qemuParams = append(config.qemuParams, "-device")
-			config.qemuParams = append(config.qemuParams, deviceMemParam)
+			config.qemuParams = append(config.qemuParams, "-numa")
+			config.qemuParams = append(config.qemuParams, numaMemParam)
 		}
 	} else if config.Knobs.FileBackedMem == true {
 		if config.Memory.Size != "" && config.Memory.Path != "" {

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -475,7 +475,7 @@ func TestAppendMemoryMemPrealloc(t *testing.T) {
 		FileBackedMem:       true,
 		FileBackedMemShared: true,
 	}
-	knobsString := "-object memory-backend-ram,id=dimm1,size=1G,prealloc=on -device pc-dimm,id=dimm1,memdev=dimm1"
+	knobsString := "-object memory-backend-ram,id=dimm1,size=1G,prealloc=on -numa node,memdev=dimm1"
 	mlockFalseString := "-realtime mlock=off"
 
 	testConfigAppend(conf, knobs, memString+" "+knobsString+" "+mlockFalseString, t)


### PR DESCRIPTION
The memory-backend-ram should also be set to a numa node instead of
being inserted as a new device. Otherwise it becomes additional memory
and requires explicit online to be available, instead of just being a
backend of the memory specified by -m option.