### PR TITLE
qemu/qmp: nic can works without vhost

### DIFF
--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -812,13 +812,15 @@ func (q *QMP) ExecuteNetdevChardevAdd(ctx context.Context, netdevType, netdevID,
 // Must be valid QMP identifier.
 func (q *QMP) ExecuteNetdevAddByFds(ctx context.Context, netdevType, netdevID string, fdNames, vhostFdNames []string) error {
 	fdNameStr := strings.Join(fdNames, ":")
-	vhostFdNameStr := strings.Join(vhostFdNames, ":")
 	args := map[string]interface{}{
-		"type":     netdevType,
-		"id":       netdevID,
-		"fds":      fdNameStr,
-		"vhost":    "on",
-		"vhostfds": vhostFdNameStr,
+		"type": netdevType,
+		"id":   netdevID,
+		"fds":  fdNameStr,
+	}
+	if len(vhostFdNames) > 0 {
+		vhostFdNameStr := strings.Join(vhostFdNames, ":")
+		args["vhost"] = "on"
+		args["vhostfds"] = vhostFdNameStr
 	}
 
 	return q.executeCommand(ctx, "netdev_add", args, nil)

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -458,10 +458,15 @@ func TestQMPNetdevAddByFds(t *testing.T) {
 	disconnectedCh := make(chan struct{})
 	buf := newQMPTestCommandBuffer(t)
 	buf.AddCommand("netdev_add", nil, "return", nil)
+	buf.AddCommand("netdev_add", nil, "return", nil)
 	cfg := QMPConfig{Logger: qmpTestLogger{}}
 	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
 	q.version = checkVersion(t, connectedCh)
-	err := q.ExecuteNetdevAddByFds(context.Background(), "tap", "br0", nil, nil)
+	err := q.ExecuteNetdevAddByFds(context.Background(), "tap", "br0", nil, []string{})
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	err = q.ExecuteNetdevAddByFds(context.Background(), "tap", "br1", nil, []string{"3"})
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}


### PR DESCRIPTION
If host doesn't support vhost_net, we won't pass vhost="on" in QMP.

Signed-off-by: Ruidong Cao <caoruidong@huawei.com>