### PR TITLE
qemu/image: Reduce permissions of .iso creation dir

### DIFF
--- a/qemu/image.go
+++ b/qemu/image.go
@@ -49,8 +49,7 @@ func CreateCloudInitISO(ctx context.Context, scratchDir, isoPath string,
 		_ = os.RemoveAll(configDrivePath)
 	}()
 
-	/* #nosec */
-	err := os.MkdirAll(dataDirPath, 0755)
+	err := os.MkdirAll(dataDirPath, 0750)
 	if err != nil {
 		return fmt.Errorf("Unable to create config drive directory %s : %v",
 			dataDirPath, err)


### PR DESCRIPTION
The contents of .iso used to bootstrap VMs with cloudinit are
initialised using a precreated, short-lived  directory.  The
permissions on this directory were too lenient.  This commit
restricts access to this directory to the user and his/her group.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>