### PR TITLE
qemu: Fix the support of PCIe bridge

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -938,18 +938,19 @@ func (bridgeDev BridgeDevice) Valid() bool {
 // QemuParams returns the qemu parameters built out of this bridge device.
 func (bridgeDev BridgeDevice) QemuParams(config *Config) []string {
 	var qemuParams []string
+	var deviceParam string
 
-	shpc := "off"
-	if bridgeDev.SHPC {
-		shpc = "on"
+	switch bridgeDev.Type {
+	case PCIEBridge:
+		deviceParam = fmt.Sprintf("pcie-pci-bridge,bus=%s,id=%s", bridgeDev.Bus, bridgeDev.ID)
+	default:
+		shpc := "off"
+		if bridgeDev.SHPC {
+			shpc = "on"
+		}
+		deviceParam = fmt.Sprintf("pci-bridge,bus=%s,id=%s,chassis_nr=%d,shpc=%s", bridgeDev.Bus, bridgeDev.ID, bridgeDev.Chassis, shpc)
 	}
 
-	deviceName := "pci-bridge"
-	if bridgeDev.Type == PCIEBridge {
-		deviceName = "pcie-pci-bridge"
-	}
-
-	deviceParam := fmt.Sprintf("%s,bus=%s,id=%s,chassis_nr=%d,shpc=%s", deviceName, bridgeDev.Bus, bridgeDev.ID, bridgeDev.Chassis, shpc)
 	if bridgeDev.Addr != "" {
 		addr, err := strconv.Atoi(bridgeDev.Addr)
 		if err == nil && addr >= 0 {

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -420,9 +420,9 @@ func TestAppendDeviceSCSIController(t *testing.T) {
 	testAppend(scsiCon, deviceSCSIControllerBusAddrStr, t)
 }
 
-var deviceBridgeString = "-device pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,chassis_nr=5,shpc=on,addr=ff"
+var devicePCIBridgeString = "-device pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,chassis_nr=5,shpc=on,addr=ff"
 
-func TestAppendBridgeDevice(t *testing.T) {
+func TestAppendPCIBridgeDevice(t *testing.T) {
 
 	bridge := BridgeDevice{
 		Type:    PCIBridge,
@@ -433,7 +433,21 @@ func TestAppendBridgeDevice(t *testing.T) {
 		SHPC:    true,
 	}
 
-	testAppend(bridge, deviceBridgeString, t)
+	testAppend(bridge, devicePCIBridgeString, t)
+}
+
+var devicePCIEBridgeString = "-device pcie-pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,addr=ff"
+
+func TestAppendPCIEBridgeDevice(t *testing.T) {
+
+	bridge := BridgeDevice{
+		Type: PCIEBridge,
+		ID:   "mybridge",
+		Bus:  "/pci-bus/pcie.0",
+		Addr: "255",
+	}
+
+	testAppend(bridge, devicePCIEBridgeString, t)
 }
 
 func TestAppendEmptyDevice(t *testing.T) {


### PR DESCRIPTION
In case the type of bridge is PCIEBridge, which we expect as ending
up using pcie-pci-bridge device from Qemu, the properties chassis_nr
and shpc don't exist.

This commit simply fixes this use case by removing those parameters
from the command line.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>