### PR TITLE
qemu: Show full path to qemu binary at launch time

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -1740,11 +1740,11 @@ func LaunchCustomQemu(ctx context.Context, path string, params []string, fds []*
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
-	logger.Infof("launching qemu with: %v", params)
+	logger.Infof("launching %s with: %v", path, params)
 
 	err := cmd.Run()
 	if err != nil {
-		logger.Errorf("Unable to launch qemu: %v", err)
+		logger.Errorf("Unable to launch %s: %v", path, err)
 		errStr = stderr.String()
 		logger.Errorf("%s", errStr)
 	}


### PR DESCRIPTION
Rather than show the generic "qemu", log the full path to the
particular qemu binary being used.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>