### PR TITLE
Reject improperly formatted golang files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
   - go get github.com/mattn/goveralls
 
 script:
+   - if [[ -n "$(gofmt -l .)" ]]; then echo "The following files were not formatted properly!"; gofmt -l .; exit 1; fi
    - go env
    - $GOPATH/bin/goveralls -v -service=travis-ci
    - gometalinter --tests --vendor --disable-all --enable=misspell --enable=vet --enable=ineffassign --enable=gofmt --enable=gocyclo --cyclo-over=15 --enable=golint --enable=errcheck --enable=deadcode --enable=staticcheck -enable=gas ./...


### PR DESCRIPTION
Adds a CI script line that invokes `gofmt` on the current directory to avoid improperly formatted files.