### PR TITLE
qemu: Fix virtio-net-pci QMP command

### DIFF
--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -912,14 +912,20 @@ func (q *QMP) ExecuteNetPCIDeviceAdd(ctx context.Context, netdevID, devID, macAd
 	args := map[string]interface{}{
 		"id":      devID,
 		"driver":  VirtioNetPCI,
-		"netdev":  netdevID,
-		"mac":     macAddr,
-		"addr":    addr,
 		"romfile": romfile,
 	}
 
 	if bus != "" {
 		args["bus"] = bus
+	}
+	if addr != "" {
+		args["addr"] = addr
+	}
+	if macAddr != "" {
+		args["mac"] = macAddr
+	}
+	if netdevID != "" {
+		args["netdev"] = netdevID
 	}
 
 	if queues > 0 {


### PR DESCRIPTION
This patch fixes the wrong behavior of specifying a netdev, MAC
address or PCI address entry when those were empty. Instead, it
does not provide those entries if the content is empty.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>