### PR TITLE
qemu/qmp: add new function ExecuteBlockdevAddWithCache

### DIFF
--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -33,10 +33,10 @@ import (
 
 const (
 	microStr = "50"
-	minorStr = "6"
+	minorStr = "9"
 	majorStr = "2"
 	micro    = 50
-	minor    = 6
+	minor    = 9
 	major    = 2
 	cap1     = "one"
 	cap2     = "two"
@@ -562,17 +562,17 @@ func TestQMPSCSIDeviceAdd(t *testing.T) {
 	<-disconnectedCh
 }
 
-// Checks that the x-blockdev-del command is correctly sent.
+// Checks that the blockdev-del command is correctly sent.
 //
-// We start a QMPLoop, send the x-blockdev-del command and stop the loop.
+// We start a QMPLoop, send the blockdev-del command and stop the loop.
 //
-// The x-blockdev-del command should be correctly sent and the QMP loop should
+// The blockdev-del command should be correctly sent and the QMP loop should
 // exit gracefully.
-func TestQMPXBlockdevDel(t *testing.T) {
+func TestQMPBlockdevDel(t *testing.T) {
 	connectedCh := make(chan *QMPVersion)
 	disconnectedCh := make(chan struct{})
 	buf := newQMPTestCommandBuffer(t)
-	buf.AddCommand("x-blockdev-del", nil, "return", nil)
+	buf.AddCommand("blockdev-del", nil, "return", nil)
 	cfg := QMPConfig{Logger: qmpTestLogger{}}
 	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
 	q.version = checkVersion(t, connectedCh)

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -403,6 +403,30 @@ func TestQMPBlockdevAdd(t *testing.T) {
 	<-disconnectedCh
 }
 
+// Checks that the blockdev-add with cache options command is correctly sent.
+//
+// We start a QMPLoop, send the blockdev-add with cache options
+// command and stop the loop.
+//
+// The blockdev-add with cache options command should be correctly sent and
+// the QMP loop should exit gracefully.
+func TestQMPBlockdevAddWithCache(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommand("blockdev-add", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	q.version = checkVersion(t, connectedCh)
+	err := q.ExecuteBlockdevAddWithCache(context.Background(), "/dev/rbd0",
+		fmt.Sprintf("drive_%s", volumeUUID), true, true)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+}
+
 // Checks that the netdev_add command is correctly sent.
 //
 // We start a QMPLoop, send the netdev_add command and stop the loop.


### PR DESCRIPTION
ExecuteBlockdevAddWithCache has two more parameters direct and noFlush
than ExecuteBlockdevAdd.
They are cache-related options for block devices that are described in
https://github.com/qemu/qemu/blob/master/qapi/block-core.json.
direct denotes whether use of O_DIRECT (bypass the host page cache)
is enabled.  noFlush denotes whether flush requests for the device are
ignored.

Signed-off-by: Hui Zhu <teawater@hyper.sh>