### PR TITLE
qemu: add support for pidfile option

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -1516,6 +1516,9 @@ type Config struct {
 
 	IOThreads []IOThread
 
+	// PidFile is the -pidfile parameter
+	PidFile string
+
 	qemuParams []string
 }
 
@@ -1830,6 +1833,13 @@ func (config *Config) appendIncoming() {
 	config.qemuParams = append(config.qemuParams, "-S", "-incoming", uri)
 }
 
+func (config *Config) appendPidFile() {
+	if config.PidFile != "" {
+		config.qemuParams = append(config.qemuParams, "-pidfile")
+		config.qemuParams = append(config.qemuParams, config.PidFile)
+	}
+}
+
 // LaunchQemu can be used to launch a new qemu instance.
 //
 // The Config parameter contains a set of qemu parameters and settings.
@@ -1855,6 +1865,7 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 	config.appendBios()
 	config.appendIOThreads()
 	config.appendIncoming()
+	config.appendPidFile()
 
 	if err := config.appendCPUs(); err != nil {
 		return "", err

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -738,7 +738,8 @@ func TestAppendQMPSocketServer(t *testing.T) {
 	testAppend(qmp, qmpSocketServerString, t)
 }
 
-var qemuString = "-name cc-qemu -cpu host -uuid " + agentUUID
+var pidfile = "/run/vc/vm/iamsandboxid/pidfile"
+var qemuString = "-name cc-qemu -cpu host -uuid " + agentUUID + " -pidfile " + pidfile
 
 func TestAppendStrings(t *testing.T) {
 	config := Config{
@@ -746,11 +747,13 @@ func TestAppendStrings(t *testing.T) {
 		Name:     "cc-qemu",
 		UUID:     agentUUID,
 		CPUModel: "host",
+		PidFile:  pidfile,
 	}
 
 	config.appendName()
 	config.appendCPUModel()
 	config.appendUUID()
+	config.appendPidFile()
 
 	result := strings.Join(config.qemuParams, " ")
 	if result != qemuString {


### PR DESCRIPTION
Add input for `-pidfile` option of qemu, so that we can get pid of
qemu main process, and apply resource limitations to it.

Fixes #62

Signed-off-by: l00397676 <lujingxiao@huawei.com>