### PR TITLE
qmp: fix mem-path properties for hotplug memory.

### DIFF
--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -1170,13 +1170,14 @@ func (q *QMP) ExecQueryCpusFast(ctx context.Context) ([]CPUInfoFast, error) {
 
 // ExecHotplugMemory adds size of MiB memory to the guest
 func (q *QMP) ExecHotplugMemory(ctx context.Context, qomtype, id, mempath string, size int) error {
+	props := map[string]interface{}{"size": uint64(size) << 20}
 	args := map[string]interface{}{
 		"qom-type": qomtype,
 		"id":       id,
-		"props":    map[string]interface{}{"size": uint64(size) << 20},
+		"props":    props,
 	}
 	if mempath != "" {
-		args["mem-path"] = mempath
+		props["mem-path"] = mempath
 	}
 	err := q.executeCommand(ctx, "object-add", args, nil)
 	if err != nil {


### PR DESCRIPTION
> "{\"error\": {\"class\": \"GenericError\", \"desc\": \"Parameter 'mem-path' is unexpected\"}}"

I got the error message when worked around hotplug memory to QEMU using host hugetlbfs.

So i checked the QMP command `object-add` code in QEMU, and found `"mem-path"` should be the key of map `"props"` instead of `"args"`.

The `object-add` be added since 2.0, and the newest 2.12 has the same definition.
https://github.com/qemu/qemu/blob/stable-2.0/qapi-schema.json#L2958
https://github.com/qemu/qemu/blob/stable-2.12/qapi/misc.json#L1846