### PR TITLE
qemu: change Context ID for Vsock to uint64

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -1014,7 +1014,7 @@ func (bridgeDev BridgeDevice) QemuParams(config *Config) []string {
 type VSOCKDevice struct {
 	ID string
 
-	ContextID uint32
+	ContextID uint64
 
 	// VHostFD vhost file descriptor that holds the ContextID
 	VHostFD *os.File
@@ -1028,7 +1028,10 @@ type VSOCKDevice struct {
 
 const (
 	// MinimalGuestCID is the smallest valid context ID for a guest.
-	MinimalGuestCID uint32 = 3
+	MinimalGuestCID uint64 = 3
+
+	// MaxGuestCID is the largest valid context ID for a guest.
+	MaxGuestCID uint64 = 1<<32 - 1
 )
 
 const (
@@ -1038,7 +1041,7 @@ const (
 
 // Valid returns true if the VSOCKDevice structure is valid and complete.
 func (vsock VSOCKDevice) Valid() bool {
-	if vsock.ID == "" || vsock.ContextID < MinimalGuestCID {
+	if vsock.ID == "" || vsock.ContextID < MinimalGuestCID || vsock.ContextID > MaxGuestCID {
 		return false
 	}
 

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -312,6 +312,12 @@ func TestVSOCKValid(t *testing.T) {
 		t.Fatalf("VSOCK Context ID is not valid")
 	}
 
+	vsockDevice.ContextID = MaxGuestCID + 1
+
+	if vsockDevice.Valid() {
+		t.Fatalf("VSOCK Context ID is not valid")
+	}
+
 	vsockDevice.ID = ""
 
 	if vsockDevice.Valid() {


### PR DESCRIPTION
The PR changes the Context ID type from `uint32` to `uint64` and checks the maximum value that the id can have 