### PR TITLE
qmp: send event without blocking

### DIFF
--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -300,7 +300,11 @@ func (q *QMP) processQMPEvent(cmdQueue *list.List, name interface{}, data interf
 			}
 		}
 
-		q.cfg.EventCh <- ev
+		select {
+		case q.cfg.EventCh <- ev:
+		default:
+			q.cfg.Logger.Warningf("The event channel buffer is full, ignore the event: %v", ev)
+		}
 	}
 }
 


### PR DESCRIPTION
The process will block if the event channel without buffer and there is data in channel already or the buffer of channel is full.
We should avoid this.

related: https://github.com/kata-containers/runtime/pull/1047

Signed-off-by: NingBo <ning.bo9@zte.com.cn>