### PR TITLE
qemu: use MiB instead of Gib for virtio-fs cache size

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -748,7 +748,7 @@ type VhostUserDevice struct {
 	TypeDevID      string //variable QEMU parameter based on value of VhostUserType
 	Address        string //used for MAC address in net case
 	Tag            string //virtio-fs volume id for mounting inside guest
-	CacheSize      uint32 //virtio-fs DAX cache size in GiB
+	CacheSize      uint32 //virtio-fs DAX cache size in MiB
 	SharedVersions bool   //enable virtio-fs shared version metadata
 	VhostUserType  DeviceDriver
 
@@ -824,7 +824,7 @@ func (vhostuserDev VhostUserDevice) QemuParams(config *Config) []string {
 		devParams = append(devParams, string(driver))
 		devParams = append(devParams, fmt.Sprintf("chardev=%s", vhostuserDev.CharDevID))
 		devParams = append(devParams, fmt.Sprintf("tag=%s", vhostuserDev.Tag))
-		devParams = append(devParams, fmt.Sprintf("cache-size=%dG", vhostuserDev.CacheSize))
+		devParams = append(devParams, fmt.Sprintf("cache-size=%dM", vhostuserDev.CacheSize))
 		if vhostuserDev.SharedVersions {
 			devParams = append(devParams, "versiontable=/dev/shm/fuse_shared_versions")
 		}


### PR DESCRIPTION
QEMU supports finer-grained units than GiB.  Change the cache size to
MiB so users have more control over the cache size.

Note that changing the semantics of the CacheSize field is fine because
there are no users of this API yet.  kata-runtime will be the first
users and prefers MiB instead of GiB.

Signed-off-by: Stefan Hajnoczi <stefanha@redhat.com>