### PR TITLE
qemu: fix the issue of wrong driver for VirtioBlock

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -71,6 +71,9 @@ const (
 	// VirtioBlock is the block device driver.
 	VirtioBlock DeviceDriver = "virtio-blk"
 
+	// VirtioBlockPCI is a pci bus block device driver
+	VirtioBlockPCI DeviceDriver = "virtio-blk-pci"
+
 	// Console is the console device driver.
 	Console DeviceDriver = "virtconsole"
 

--- a/qemu/qemu_arch_base.go
+++ b/qemu/qemu_arch_base.go
@@ -47,6 +47,7 @@ var isVirtioPCI = map[DeviceDriver]bool{
 	VirtioNetPCI:        true,
 	VirtioSerial:        true,
 	VirtioBlock:         true,
+	VirtioBlockPCI:      true,
 	Console:             false,
 	VirtioSerialPort:    false,
 	VHostVSock:          true,


### PR DESCRIPTION
The driver for VirtioBlock should "virtio-blk-pci" instead
of "virtio-blk".

Fixes:#92

Signed-off-by: lifupan <lifupan@gmail.com>