### PR TITLE
Allow sharing of memory backend file

### DIFF
--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -1285,7 +1285,7 @@ func (q *QMP) ExecQueryCpusFast(ctx context.Context) ([]CPUInfoFast, error) {
 }
 
 // ExecHotplugMemory adds size of MiB memory to the guest
-func (q *QMP) ExecHotplugMemory(ctx context.Context, qomtype, id, mempath string, size int) error {
+func (q *QMP) ExecHotplugMemory(ctx context.Context, qomtype, id, mempath string, size int, share bool) error {
 	props := map[string]interface{}{"size": uint64(size) << 20}
 	args := map[string]interface{}{
 		"qom-type": qomtype,
@@ -1294,6 +1294,9 @@ func (q *QMP) ExecHotplugMemory(ctx context.Context, qomtype, id, mempath string
 	}
 	if mempath != "" {
 		props["mem-path"] = mempath
+	}
+	if share {
+		props["share"] = true
 	}
 	err := q.executeCommand(ctx, "object-add", args, nil)
 	if err != nil {

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -1273,7 +1273,7 @@ func TestExecHotplugMemory(t *testing.T) {
 	cfg := QMPConfig{Logger: qmpTestLogger{}}
 	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
 	checkVersion(t, connectedCh)
-	err := q.ExecHotplugMemory(context.Background(), "memory-backend-ram", "mem0", "", 128)
+	err := q.ExecHotplugMemory(context.Background(), "memory-backend-ram", "mem0", "", 128, true)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}


### PR DESCRIPTION
Hotplugged memory could be backed by a file on the host with sharing
turned on. This change allows qmp to pass that option to a govmm.

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>