### PR TITLE
Support x-pci-vendor-id and x-pci-device-id pass to qemu

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -901,6 +901,12 @@ type VFIODevice struct {
 
 	// DevNo identifies the ccw devices for s390x architecture
 	DevNo string
+
+	// VendorID specifies vendor id
+	VendorID string
+
+	// DeviceID specifies device id
+	DeviceID string
 }
 
 // Valid returns true if the VFIODevice structure is valid and complete.
@@ -917,6 +923,12 @@ func (vfioDev VFIODevice) QemuParams(config *Config) []string {
 
 	deviceParams = append(deviceParams, fmt.Sprintf("%s,host=%s", driver, vfioDev.BDF))
 	if isVirtioPCI[driver] {
+		if vfioDev.VendorID != "" {
+			deviceParams = append(deviceParams, fmt.Sprintf(",x-pci-vendor-id=%s", vfioDev.VendorID))
+		}
+		if vfioDev.DeviceID != "" {
+			deviceParams = append(deviceParams, fmt.Sprintf(",x-pci-device-id=%s", vfioDev.DeviceID))
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf(",romfile=%s", vfioDev.ROMFile))
 	}
 

--- a/qemu/qemu_arch_base_test.go
+++ b/qemu/qemu_arch_base_test.go
@@ -27,7 +27,7 @@ var (
 	deviceSerialString             = "-device virtio-serial-pci,disable-modern=true,id=serial0,romfile=efi-virtio.rom"
 	deviceVhostUserNetString       = "-chardev socket,id=char1,path=/tmp/nonexistentsocket.socket -netdev type=vhost-user,id=net1,chardev=char1,vhostforce -device virtio-net-pci,netdev=net1,mac=00:11:22:33:44:55,romfile=efi-virtio.rom"
 	deviceVSOCKString              = "-device vhost-vsock-pci,disable-modern=true,id=vhost-vsock-pci0,guest-cid=4,romfile=efi-virtio.rom"
-	deviceVFIOString               = "-device vfio-pci,host=02:10.0,romfile=efi-virtio.rom"
+	deviceVFIOString               = "-device vfio-pci,host=02:10.0,x-pci-vendor-id=0x1234,x-pci-device-id=0x5678,romfile=efi-virtio.rom"
 	deviceSCSIControllerStr        = "-device virtio-scsi-pci,id=foo,disable-modern=false,romfile=efi-virtio.rom"
 	deviceSCSIControllerBusAddrStr = "-device virtio-scsi-pci,id=foo,bus=pci.0,addr=00:04.0,disable-modern=true,iothread=iothread1,romfile=efi-virtio.rom"
 	deviceVhostUserSCSIString      = "-chardev socket,id=char1,path=/tmp/nonexistentsocket.socket -device vhost-user-scsi-pci,id=scsi1,chardev=char1,romfile=efi-virtio.rom"

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -312,8 +312,10 @@ func TestAppendDeviceBlock(t *testing.T) {
 
 func TestAppendDeviceVFIO(t *testing.T) {
 	vfioDevice := VFIODevice{
-		BDF:     "02:10.0",
-		ROMFile: romfile,
+		BDF:      "02:10.0",
+		ROMFile:  romfile,
+		VendorID: "0x1234",
+		DeviceID: "0x5678",
 	}
 
 	if isVirtioCCW[Vfio] {


### PR DESCRIPTION
Close #97 

As the issue says, in our environment, sometimes need to specified vendor-id and device-id.