### PR TITLE
qemu: support x86 SMP die

### DIFF
--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -149,6 +149,7 @@ type QMPVersion struct {
 type CPUProperties struct {
 	Node   int `json:"node-id"`
 	Socket int `json:"socket-id"`
+	Die    int `json:"die-id"`
 	Core   int `json:"core-id"`
 	Thread int `json:"thread-id"`
 }
@@ -1162,7 +1163,7 @@ func (q *QMP) ExecutePCIVFIOMediatedDeviceAdd(ctx context.Context, devID, sysfsd
 // node/board the CPU belongs to, coreID is the core number within socket the CPU belongs to, threadID is the
 // thread number within core the CPU belongs to. Note that socketID and threadID are not a requirement for
 // architecures like ppc64le.
-func (q *QMP) ExecuteCPUDeviceAdd(ctx context.Context, driver, cpuID, socketID, coreID, threadID, romfile string) error {
+func (q *QMP) ExecuteCPUDeviceAdd(ctx context.Context, driver, cpuID, socketID, dieID, coreID, threadID, romfile string) error {
 	args := map[string]interface{}{
 		"driver":  driver,
 		"id":      cpuID,
@@ -1175,6 +1176,12 @@ func (q *QMP) ExecuteCPUDeviceAdd(ctx context.Context, driver, cpuID, socketID, 
 
 	if threadID != "" {
 		args["thread-id"] = threadID
+	}
+
+	if q.version.Major > 4 || (q.version.Major == 4 && q.version.Minor >= 1) {
+		if dieID != "" {
+			args["die-id"] = dieID
+		}
 	}
 
 	if isVirtioPCI[DeviceDriver(driver)] {

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -1069,9 +1069,14 @@ func TestQMPCPUDeviceAdd(t *testing.T) {
 	driver := "qemu64-x86_64-cpu"
 	cpuID := "cpu-0"
 	socketID := "0"
+	dieID := "0"
 	coreID := "1"
 	threadID := "0"
-	err := q.ExecuteCPUDeviceAdd(context.Background(), driver, cpuID, socketID, coreID, threadID, "")
+	q.version = &QMPVersion{
+		Major: 4,
+		Minor: 1,
+	}
+	err := q.ExecuteCPUDeviceAdd(context.Background(), driver, cpuID, socketID, dieID, coreID, threadID, "")
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}
@@ -1090,6 +1095,7 @@ func TestQMPExecuteQueryHotpluggableCPUs(t *testing.T) {
 		Properties: CPUProperties{
 			Node:   1,
 			Socket: 3,
+			Die:    1,
 			Core:   2,
 			Thread: 4,
 		},


### PR DESCRIPTION
In QEMU 4.1 the CPU topology for x86 will change to:
`socket > die > core > thread`.
Add `die-id` field to `CPUProperties` and include it in CPU hotplugging

Signed-off-by: Julio Montes <julio.montes@intel.com>