### PR TITLE
qmp: add checks for the CPU toplogy

### DIFF
--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -1158,6 +1158,30 @@ func (q *QMP) ExecutePCIVFIOMediatedDeviceAdd(ctx context.Context, devID, sysfsd
 	return q.executeCommand(ctx, "device_add", args, nil)
 }
 
+// isSocketIDSupported returns if the cpu driver supports the socket id option
+func isSocketIDSupported(driver string) bool {
+	if driver == "host-s390x-cpu" || driver == "host-powerpc64-cpu" {
+		return false
+	}
+	return true
+}
+
+// isThreadIDSupported returns if the cpu driver supports the thread id option
+func isThreadIDSupported(driver string) bool {
+	if driver == "host-s390x-cpu" || driver == "host-powerpc64-cpu" {
+		return false
+	}
+	return true
+}
+
+// isDieIDSupported returns if the cpu driver and the qemu version support the die id option
+func (q *QMP) isDieIDSupported(driver string) bool {
+	if (q.version.Major > 4 || (q.version.Major == 4 && q.version.Minor >= 1)) && driver == "host-x86_64-cpu" {
+		return true
+	}
+	return false
+}
+
 // ExecuteCPUDeviceAdd adds a CPU to a QEMU instance using the device_add command.
 // driver is the CPU model, cpuID must be a unique ID to identify the CPU, socketID is the socket number within
 // node/board the CPU belongs to, coreID is the core number within socket the CPU belongs to, threadID is the
@@ -1170,15 +1194,15 @@ func (q *QMP) ExecuteCPUDeviceAdd(ctx context.Context, driver, cpuID, socketID, 
 		"core-id": coreID,
 	}
 
-	if socketID != "" {
+	if socketID != "" && isSocketIDSupported(driver) {
 		args["socket-id"] = socketID
 	}
 
-	if threadID != "" {
+	if threadID != "" && isThreadIDSupported(driver) {
 		args["thread-id"] = threadID
 	}
 
-	if q.version.Major > 4 || (q.version.Major == 4 && q.version.Minor >= 1) {
+	if q.isDieIDSupported(driver) {
 		if dieID != "" {
 			args["die-id"] = dieID
 		}


### PR DESCRIPTION
Support for function isSocketIDSupported, isThreadIDSupported and isDieIDSupported.
The functions check if the cpu driver and the qemu version support the
id parameter.

Fixes: #102

The support table for various param looks like:

| Arch | cpu driver             | socket id | thread id | die id | cpu hotplug |
| ---     |  ---                         |      ---        |   ---         |  --       | ---- |
| x86_64 |    host-x86_64-cpu | y               |   y           | y   ( >= Qemu 4.1)     | y |
| s390x |        host-s390x-cpu | n | n |n | y | 
| arm64  |        host-arm-cpu                   |    y             |   y           |    n        | n |
| ppc64le |     host-powerpc64-cpu     |    n             | n             |     n      |    y |

taken from https://github.com/intel/govmm/pull/101#discussion_r304384630

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>