### PR TITLE
s390x: add s390x travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ go:
     - "1.10"
     - "1.11"
     - tip
+arch:
+    - amd64
+    - s390x
 
 go_import_path: github.com/intel/govmm
 
@@ -20,5 +23,3 @@ script:
    - go env
    - $GOPATH/bin/goveralls -v -service=travis-ci
    - gometalinter --tests --vendor --disable-all --enable=misspell --enable=vet --enable=ineffassign --enable=gofmt --enable=gocyclo --cyclo-over=15 --enable=golint --enable=errcheck --enable=deadcode --enable=staticcheck -enable=gas ./...
-   - GOARCH=s390x go install ./...
-   - go test --tags s390x_test ./...

--- a/qemu/qemu_arch_base.go
+++ b/qemu/qemu_arch_base.go
@@ -1,4 +1,4 @@
-// +build !s390x,!s390x_test
+// +build !s390x
 
 /*
 // Copyright contributors to the Virtual Machine Manager for Go project

--- a/qemu/qemu_arch_base_test.go
+++ b/qemu/qemu_arch_base_test.go
@@ -1,4 +1,4 @@
-// +build !s390x,!s390x_test
+// +build !s390x
 
 /*
 // Copyright contributors to the Virtual Machine Manager for Go project

--- a/qemu/qemu_s390x.go
+++ b/qemu/qemu_s390x.go
@@ -1,4 +1,4 @@
-// +build s390x s390x_test
+// +build s390x
 
 /*
 // Copyright contributors to the Virtual Machine Manager for Go project

--- a/qemu/qemu_s390x_test.go
+++ b/qemu/qemu_s390x_test.go
@@ -1,4 +1,4 @@
-// +build s390x s390x_test
+// +build s390x
 
 /*
 // Copyright contributors to the Virtual Machine Manager for Go project


### PR DESCRIPTION
Since we have travis support for s390x. Let's enable it

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>