### PR TITLE
qemu: add block device readonly support

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -971,6 +971,9 @@ type BlockDevice struct {
 	// ShareRW enables multiple qemu instances to share the File
 	ShareRW bool
 
+	// ReadOnly sets the block device in readonly mode
+	ReadOnly bool
+
 	// Transport is the virtio transport for this device.
 	Transport VirtioTransport
 }
@@ -1028,6 +1031,10 @@ func (blkdev BlockDevice) QemuParams(config *Config) []string {
 	blkParams = append(blkParams, fmt.Sprintf(",aio=%s", blkdev.AIO))
 	blkParams = append(blkParams, fmt.Sprintf(",format=%s", blkdev.Format))
 	blkParams = append(blkParams, fmt.Sprintf(",if=%s", blkdev.Interface))
+
+	if blkdev.ReadOnly {
+		blkParams = append(blkParams, ",readonly")
+	}
 
 	qemuParams = append(qemuParams, "-device")
 	qemuParams = append(qemuParams, strings.Join(deviceParams, ""))

--- a/qemu/qemu_arch_base_test.go
+++ b/qemu/qemu_arch_base_test.go
@@ -36,7 +36,7 @@ var (
 	deviceSCSIControllerBusAddrStr = "-device virtio-scsi-pci,id=foo,bus=pci.0,addr=00:04.0,disable-modern=true,iothread=iothread1,romfile=efi-virtio.rom"
 	deviceVhostUserSCSIString      = "-chardev socket,id=char1,path=/tmp/nonexistentsocket.socket -device vhost-user-scsi-pci,id=scsi1,chardev=char1,romfile=efi-virtio.rom"
 	deviceVhostUserBlkString       = "-chardev socket,id=char2,path=/tmp/nonexistentsocket.socket -device vhost-user-blk-pci,logical_block_size=4096,size=512M,chardev=char2,romfile=efi-virtio.rom"
-	deviceBlockString              = "-device virtio-blk-pci,disable-modern=true,drive=hd0,scsi=off,config-wce=off,romfile=efi-virtio.rom -drive id=hd0,file=/var/lib/vm.img,aio=threads,format=qcow2,if=none"
+	deviceBlockString              = "-device virtio-blk-pci,disable-modern=true,drive=hd0,scsi=off,config-wce=off,romfile=efi-virtio.rom,share-rw=on -drive id=hd0,file=/var/lib/vm.img,aio=threads,format=qcow2,if=none,readonly"
 	devicePCIBridgeString          = "-device pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,chassis_nr=5,shpc=on,addr=ff,romfile=efi-virtio.rom"
 	devicePCIEBridgeString         = "-device pcie-pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,addr=ff,romfile=efi-virtio.rom"
 	romfile                        = "efi-virtio.rom"

--- a/qemu/qemu_s390x_test.go
+++ b/qemu/qemu_s390x_test.go
@@ -31,7 +31,7 @@ var (
 	deviceVFIOString               = "-device vfio-ccw,host=02:10.0,devno=" + DevNo
 	deviceSCSIControllerStr        = "-device virtio-scsi-ccw,id=foo,devno=" + DevNo
 	deviceSCSIControllerBusAddrStr = "-device virtio-scsi-ccw,id=foo,bus=pci.0,addr=00:04.0,iothread=iothread1,devno=" + DevNo
-	deviceBlockString              = "-device virtio-blk-ccw,drive=hd0,scsi=off,config-wce=off,devno=" + DevNo + " -drive id=hd0,file=/var/lib/vm.img,aio=threads,format=qcow2,if=none"
+	deviceBlockString              = "-device virtio-blk-ccw,drive=hd0,scsi=off,config-wce=off,devno=" + DevNo + ",share-rw=on -drive id=hd0,file=/var/lib/vm.img,aio=threads,format=qcow2,if=none,readonly"
 	devicePCIBridgeString          = "-device pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,chassis_nr=5,shpc=on,addr=ff"
 	devicePCIEBridgeString         = "-device pcie-pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,addr=ff"
 	romfile                        = ""

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -303,6 +303,8 @@ func TestAppendDeviceBlock(t *testing.T) {
 		WCE:           false,
 		DisableModern: true,
 		ROMFile:       romfile,
+		ShareRW:       true,
+		ReadOnly:      true,
 	}
 	if blkdev.Transport.isVirtioCCW(nil) {
 		blkdev.DevNo = DevNo


### PR DESCRIPTION
So that we can attach it readonly.

Signed-off-by: Peng Tao <bergwolf@hyper.sh>