### PR TITLE
qmp: Add ExecMemdevAdd and ExecQomSet API

### DIFF
--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -1379,8 +1379,8 @@ func (q *QMP) ExecQueryCpusFast(ctx context.Context) ([]CPUInfoFast, error) {
 	return cpuInfoFast, nil
 }
 
-// ExecHotplugMemory adds size of MiB memory to the guest
-func (q *QMP) ExecHotplugMemory(ctx context.Context, qomtype, id, mempath string, size int, share bool) error {
+// ExecMemdevAdd adds size of MiB memory device to the guest
+func (q *QMP) ExecMemdevAdd(ctx context.Context, qomtype, id, mempath string, size int, share bool, driver, driverID string) error {
 	props := map[string]interface{}{"size": uint64(size) << 20}
 	args := map[string]interface{}{
 		"qom-type": qomtype,
@@ -1400,22 +1400,27 @@ func (q *QMP) ExecHotplugMemory(ctx context.Context, qomtype, id, mempath string
 
 	defer func() {
 		if err != nil {
-			q.cfg.Logger.Errorf("Unable to hotplug memory device: %v", err)
+			q.cfg.Logger.Errorf("Unable to add memory device %s: %v", id, err)
 			err = q.executeCommand(ctx, "object-del", map[string]interface{}{"id": id}, nil)
 			if err != nil {
-				q.cfg.Logger.Warningf("Unable to clean up memory object: %v", err)
+				q.cfg.Logger.Warningf("Unable to clean up memory object %s: %v", id, err)
 			}
 		}
 	}()
 
 	args = map[string]interface{}{
-		"driver": "pc-dimm",
-		"id":     "dimm" + id,
+		"driver": driver,
+		"id":     driverID,
 		"memdev": id,
 	}
 	err = q.executeCommand(ctx, "device_add", args, nil)
 
 	return err
+}
+
+// ExecHotplugMemory adds size of MiB memory to the guest
+func (q *QMP) ExecHotplugMemory(ctx context.Context, qomtype, id, mempath string, size int, share bool) error {
+	return q.ExecMemdevAdd(ctx, qomtype, id, mempath, size, share, "pc-dimm", "dimm"+id)
 }
 
 // ExecuteNVDIMMDeviceAdd adds a block device to a QEMU instance using
@@ -1603,4 +1608,15 @@ func (q *QMP) ExecuteQueryStatus(ctx context.Context) (StatusInfo, error) {
 	}
 
 	return status, nil
+}
+
+// ExecQomSet qom-set path property value
+func (q *QMP) ExecQomSet(ctx context.Context, path, property string, value uint64) error {
+	args := map[string]interface{}{
+		"path":     path,
+		"property": property,
+		"value":    value,
+	}
+
+	return q.executeCommand(ctx, "qom-set", args, nil)
 }


### PR DESCRIPTION
Add ExecMemdevAdd and ExecQomSet API to support virtio-mem.

Signed-off-by: Hui Zhu <teawater@antfin.com>