### PR TITLE
qemu: Don't set ".cache-size=" when CacheSize is 0

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -875,7 +875,9 @@ func (vhostuserDev VhostUserDevice) QemuParams(config *Config) []string {
 		devParams = append(devParams, string(driver))
 		devParams = append(devParams, fmt.Sprintf("chardev=%s", vhostuserDev.CharDevID))
 		devParams = append(devParams, fmt.Sprintf("tag=%s", vhostuserDev.Tag))
-		devParams = append(devParams, fmt.Sprintf("cache-size=%dM", vhostuserDev.CacheSize))
+		if vhostuserDev.CacheSize != 0 {
+			devParams = append(devParams, fmt.Sprintf("cache-size=%dM", vhostuserDev.CacheSize))
+		}
 		if vhostuserDev.SharedVersions {
 			devParams = append(devParams, "versiontable=/dev/shm/fuse_shared_versions")
 		}


### PR DESCRIPTION
As there's no guarantee that ".cache-size" is a supported QEMU property,
let's not add it to the QEMU command line when the user explicitly set
virtio_fs_cache_size to zero.

By not always setting ".cache-size" property we avoid errors like:
```
$ sudo podman --runtime=/usr/bin/kata-runtime run --security-opt label=disable -it fedora:31 /bin/bash
Error: failed to launch qemu: exit status 1, error messages from qemu log: qemu-kvm: -device vhost-user-fs-pci,chardev=char-88c350403e95d3db,tag=kataShared,cache-size=0M: Property '.cache-size' not found: OCI runtime error
```

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>