### PR TITLE
qemu: add pmem flag to memory-backend-file

### DIFF
--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -1617,7 +1617,12 @@ func TestExecuteNVDIMMDeviceAdd(t *testing.T) {
 	cfg := QMPConfig{Logger: qmpTestLogger{}}
 	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
 	checkVersion(t, connectedCh)
-	err := q.ExecuteNVDIMMDeviceAdd(context.Background(), "nvdimm0", "/dev/rbd0", 1024)
+	q.version = &QMPVersion{
+		Major: 4,
+		Minor: 1,
+	}
+	pmem := true
+	err := q.ExecuteNVDIMMDeviceAdd(context.Background(), "nvdimm0", "/dev/rbd0", 1024, &pmem)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}


### PR DESCRIPTION
According to QEMU's nvdimm documentation: When 'pmem' is 'on' and QEMU is
built with libpmem support, QEMU will take necessary operations to guarantee
the persistence of its own writes to the vNVDIMM backend.

Signed-off-by: Julio Montes <julio.montes@intel.com>