### PR TITLE
qemu: Add microvm machine type support

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -51,6 +51,11 @@ type Machine struct {
 	Options string
 }
 
+const (
+	// MachineTypeMicrovm is the QEMU microvm machine type for amd64
+	MachineTypeMicrovm string = "microvm"
+)
+
 // Device is the qemu device interface.
 type Device interface {
 	Valid() bool
@@ -128,6 +133,10 @@ const (
 func isDimmSupported(config *Config) bool {
 	switch runtime.GOARCH {
 	case "amd64", "386":
+		if config != nil && config.Machine.Type == MachineTypeMicrovm {
+			// microvm does not support NUMA
+			return false
+		}
 		return true
 	default:
 		return false
@@ -153,6 +162,9 @@ const (
 func (transport VirtioTransport) defaultTransport(config *Config) VirtioTransport {
 	switch runtime.GOARCH {
 	case "amd64", "386":
+		if config != nil && config.Machine.Type == MachineTypeMicrovm {
+			return TransportMMIO
+		}
 		return TransportPCI
 	case "s390x":
 		return TransportCCW

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -108,6 +108,14 @@ func TestAppendMachine(t *testing.T) {
 		Options:      "gic-version=host,usb=off",
 	}
 	testAppend(machine, machineString, t)
+
+	machineString = "-machine microvm,accel=kvm,pic=off,pit=off"
+	machine = Machine{
+		Type:         "microvm",
+		Acceleration: "kvm",
+		Options:      "pic=off,pit=off",
+	}
+	testAppend(machine, machineString, t)
 }
 
 func TestAppendEmptyMachine(t *testing.T) {


### PR DESCRIPTION
Following on from #111 which added support for multiple virtio transports,
add code to use virtio-mmio as the transport when booting a guest with
the microvm machine type and add a microvm case when checking for
NUMA support. Also add a test case for machine string parsing.

Signed-off-by: Liam Merwick <liam.merwick@oracle.com>