### PR TITLE
qemu: Add max_ports option to virtio-serial device

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -880,6 +880,9 @@ type SerialDevice struct {
 
 	// Transport is the virtio transport for this device.
 	Transport VirtioTransport
+
+	// MaxPorts is the maximum number of ports for this device.
+	MaxPorts uint
 }
 
 // Valid returns true if the SerialDevice structure is valid and complete.
@@ -903,6 +906,9 @@ func (dev SerialDevice) QemuParams(config *Config) []string {
 	deviceParams = append(deviceParams, fmt.Sprintf(",id=%s", dev.ID))
 	if dev.Transport.isVirtioPCI(config) {
 		deviceParams = append(deviceParams, fmt.Sprintf(",romfile=%s", dev.ROMFile))
+		if dev.Driver == VirtioSerial && dev.MaxPorts != 0 {
+			deviceParams = append(deviceParams, fmt.Sprintf(",max_ports=%d", dev.MaxPorts))
+		}
 	}
 
 	if dev.Transport.isVirtioCCW(config) {

--- a/qemu/qemu_arch_base_test.go
+++ b/qemu/qemu_arch_base_test.go
@@ -24,7 +24,7 @@ var (
 	deviceFSString                 = "-device virtio-9p-pci,disable-modern=true,fsdev=workload9p,mount_tag=rootfs,romfile=efi-virtio.rom -fsdev local,id=workload9p,path=/var/lib/docker/devicemapper/mnt/e31ebda2,security_model=none"
 	deviceNetworkString            = "-netdev tap,id=tap0,vhost=on,ifname=ceth0,downscript=no,script=no -device driver=virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,disable-modern=true,romfile=efi-virtio.rom"
 	deviceNetworkStringMq          = "-netdev tap,id=tap0,vhost=on,fds=3:4 -device driver=virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,disable-modern=true,mq=on,vectors=6,romfile=efi-virtio.rom"
-	deviceSerialString             = "-device virtio-serial-pci,disable-modern=true,id=serial0,romfile=efi-virtio.rom"
+	deviceSerialString             = "-device virtio-serial-pci,disable-modern=true,id=serial0,romfile=efi-virtio.rom,max_ports=2"
 	deviceVhostUserNetString       = "-chardev socket,id=char1,path=/tmp/nonexistentsocket.socket -netdev type=vhost-user,id=net1,chardev=char1,vhostforce -device virtio-net-pci,netdev=net1,mac=00:11:22:33:44:55,romfile=efi-virtio.rom"
 	deviceVSOCKString              = "-device vhost-vsock-pci,disable-modern=true,id=vhost-vsock-pci0,guest-cid=4,romfile=efi-virtio.rom"
 	deviceVFIOString               = "-device vfio-pci,host=02:10.0,x-pci-vendor-id=0x1234,x-pci-device-id=0x5678,romfile=efi-virtio.rom"

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -274,6 +274,7 @@ func TestAppendDeviceSerial(t *testing.T) {
 		ID:            "serial0",
 		DisableModern: true,
 		ROMFile:       romfile,
+		MaxPorts:      2,
 	}
 	if sdev.Transport.isVirtioCCW(nil) {
 		sdev.DevNo = DevNo


### PR DESCRIPTION
Allow API consumers to change the maximum number of ports in the virtio-serial
devices, setting a lower number of ports can improve the boot time and
reduce the attack surface.

fixes #120

Signed-off-by: Julio Montes <julio.montes@intel.com>