### PR TITLE
qemu: add IOMMU Device

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -1861,6 +1861,52 @@ func (b BalloonDevice) deviceName(config *Config) string {
 	return BalloonDeviceTransport[b.Transport]
 }
 
+// IommuDev represents a Intel IOMMU Device
+type IommuDev struct {
+	Intremap    bool
+	DeviceIotlb bool
+	CachingMode bool
+}
+
+// Valid returns true if the IommuDev is valid
+func (dev IommuDev) Valid() bool {
+	return true
+}
+
+// deviceName the qemu device name
+func (dev IommuDev) deviceName() string {
+	return "intel-iommu"
+}
+
+// QemuParams returns the qemu parameters built out of the IommuDev.
+func (dev IommuDev) QemuParams(_ *Config) []string {
+	var qemuParams []string
+	var deviceParams []string
+
+	deviceParams = append(deviceParams, dev.deviceName())
+	if dev.Intremap {
+		deviceParams = append(deviceParams, "intremap=on")
+	} else {
+		deviceParams = append(deviceParams, "intremap=off")
+	}
+
+	if dev.DeviceIotlb {
+		deviceParams = append(deviceParams, "device-iotlb=on")
+	} else {
+		deviceParams = append(deviceParams, "device-iotlb=off")
+	}
+
+	if dev.CachingMode {
+		deviceParams = append(deviceParams, "caching-mode=on")
+	} else {
+		deviceParams = append(deviceParams, "caching-mode=off")
+	}
+
+	qemuParams = append(qemuParams, "-device")
+	qemuParams = append(qemuParams, strings.Join(deviceParams, ","))
+	return qemuParams
+}
+
 // RTCBaseType is the qemu RTC base time type.
 type RTCBaseType string
 

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -1125,3 +1125,27 @@ func TestBadCPUs(t *testing.T) {
 		t.Errorf("Error expected")
 	}
 }
+
+var (
+	vIommuString        = "-device intel-iommu,intremap=on,device-iotlb=on,caching-mode=on"
+	vIommuNoCacheString = "-device intel-iommu,intremap=on,device-iotlb=on,caching-mode=off"
+)
+
+func TestIommu(t *testing.T) {
+	iommu := IommuDev{
+		Intremap:    true,
+		DeviceIotlb: true,
+		CachingMode: true,
+	}
+
+	if !iommu.Valid() {
+		t.Fatalf("iommu should be valid")
+	}
+
+	testAppend(iommu, vIommuString, t)
+
+	iommu.CachingMode = false
+
+	testAppend(iommu, vIommuNoCacheString, t)
+
+}


### PR DESCRIPTION
The following options can be provided:
Intremap: activates interrupt remapping
DeviceIotlb: enables device IOTLB support for the vIOMMU
CachingMode: enables Cahing Mode

See: https://wiki.qemu.org/Features/VT-d

Fixes: #126 
Signed-off-by: Adrian Moreno <amorenoz@redhat.com>