### PR TITLE
qemu/qmp: use boolean type for the vhost

### DIFF
--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -993,7 +993,7 @@ func (q *QMP) ExecuteNetdevAddByFds(ctx context.Context, netdevType, netdevID st
 	}
 	if len(vhostFdNames) > 0 {
 		vhostFdNameStr := strings.Join(vhostFdNames, ":")
-		args["vhost"] = "on"
+		args["vhost"] = true
 		args["vhostfds"] = vhostFdNameStr
 	}
 


### PR DESCRIPTION
vhost is a Netdev Tap Option used to configure a host TAP network interface
backend, according to the QMP API documentation the type for such option must
be a boolean. Use boolean type for vhost option to fix the following
error on recent versions of QEMU:

```
Invalid parameter type for 'vhost', expected: boolean
```

cc @amshinde 

Signed-off-by: Julio Montes <julio.montes@intel.com>