### PR TITLE
Add multidevs option to fsdev

### DIFF
--- a/qemu/qemu_arch_base_test.go
+++ b/qemu/qemu_arch_base_test.go
@@ -21,7 +21,7 @@ package qemu
 import "testing"
 
 var (
-	deviceFSString                 = "-device virtio-9p-pci,disable-modern=true,fsdev=workload9p,mount_tag=rootfs,romfile=efi-virtio.rom -fsdev local,id=workload9p,path=/var/lib/docker/devicemapper/mnt/e31ebda2,security_model=none"
+	deviceFSString                 = "-device virtio-9p-pci,disable-modern=true,fsdev=workload9p,mount_tag=rootfs,romfile=efi-virtio.rom -fsdev local,id=workload9p,path=/var/lib/docker/devicemapper/mnt/e31ebda2,security_model=none,multidevs=remap"
 	deviceNetworkString            = "-netdev tap,id=tap0,vhost=on,ifname=ceth0,downscript=no,script=no -device driver=virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,disable-modern=true,romfile=efi-virtio.rom"
 	deviceNetworkStringMq          = "-netdev tap,id=tap0,vhost=on,fds=3:4 -device driver=virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,disable-modern=true,mq=on,vectors=6,romfile=efi-virtio.rom"
 	deviceSerialString             = "-device virtio-serial-pci,disable-modern=true,id=serial0,romfile=efi-virtio.rom,max_ports=2"

--- a/qemu/qemu_s390x_test.go
+++ b/qemu/qemu_s390x_test.go
@@ -23,7 +23,7 @@ import "testing"
 // -pci devices don't play well with Z hence replace them with corresponding -ccw devices
 // See https://wiki.qemu.org/Documentation/Platforms/S390X
 var (
-	deviceFSString                 = "-device virtio-9p-ccw,fsdev=workload9p,mount_tag=rootfs,devno=" + DevNo + " -fsdev local,id=workload9p,path=/var/lib/docker/devicemapper/mnt/e31ebda2,security_model=none"
+	deviceFSString                 = "-device virtio-9p-ccw,fsdev=workload9p,mount_tag=rootfs,devno=" + DevNo + " -fsdev local,id=workload9p,path=/var/lib/docker/devicemapper/mnt/e31ebda2,security_model=none,multidevs=remap"
 	deviceNetworkString            = "-netdev tap,id=tap0,vhost=on,ifname=ceth0,downscript=no,script=no -device driver=virtio-net-ccw,netdev=tap0,mac=01:02:de:ad:be:ef,devno=" + DevNo
 	deviceNetworkStringMq          = "-netdev tap,id=tap0,vhost=on,fds=3:4 -device driver=virtio-net-ccw,netdev=tap0,mac=01:02:de:ad:be:ef,mq=on,devno=" + DevNo
 	deviceSerialString             = "-device virtio-serial-ccw,id=serial0,devno=" + DevNo

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -149,6 +149,7 @@ func TestAppendDeviceFS(t *testing.T) {
 		SecurityModel: None,
 		DisableModern: true,
 		ROMFile:       "efi-virtio.rom",
+		Multidev:      Remap,
 	}
 
 	if fsdev.Transport.isVirtioCCW(nil) {


### PR DESCRIPTION
multidevs specifies how to deal with multiple devices being shared with a 9p
export. `multidevs=remap` fixes the following warning:

```
9p: Multiple devices detected in same VirtFS export, which might lead to file
ID collisions and severe misbehaviours on guest!
You should either use a separate export for each device shared from host or
use virtfs option 'multidevs=remap'!
```

Signed-off-by: Julio Montes <julio.montes@intel.com>