### PR TITLE
qemu: Add NoReboot config Knob for qemuParams

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -2122,6 +2122,9 @@ type Knobs struct {
 
 	// Realtime will enable realtime QEMU
 	Realtime bool
+
+	// Exit instead of rebooting
+	NoReboot bool
 }
 
 // IOThread allows IO to be performed on a separate thread.
@@ -2455,6 +2458,10 @@ func (config *Config) appendKnobs() {
 
 	if config.Knobs.NoGraphic {
 		config.qemuParams = append(config.qemuParams, "-nographic")
+	}
+
+	if config.Knobs.NoReboot {
+		config.qemuParams = append(config.qemuParams, "--no-reboot")
 	}
 
 	if config.Knobs.Daemonize {

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -501,11 +501,12 @@ func TestAppendEmptyDevice(t *testing.T) {
 }
 
 func TestAppendKnobsAllTrue(t *testing.T) {
-	var knobsString = "-no-user-config -nodefaults -nographic -daemonize -realtime mlock=on -S"
+	var knobsString = "-no-user-config -nodefaults -nographic --no-reboot -daemonize -realtime mlock=on -S"
 	knobs := Knobs{
 		NoUserConfig:  true,
 		NoDefaults:    true,
 		NoGraphic:     true,
+		NoReboot:      true,
 		Daemonize:     true,
 		MemPrealloc:   true,
 		FileBackedMem: true,
@@ -524,6 +525,7 @@ func TestAppendKnobsAllFalse(t *testing.T) {
 		NoUserConfig:  false,
 		NoDefaults:    false,
 		NoGraphic:     false,
+		NoReboot:      false,
 		MemPrealloc:   false,
 		FileBackedMem: false,
 		MemShared:     false,
@@ -666,6 +668,18 @@ func TestAppendMemoryFileBackedMemPrealloc(t *testing.T) {
 	mlockFalseString := "-realtime mlock=off"
 
 	testConfigAppend(conf, knobs, memString+" "+knobsString+" "+mlockFalseString, t)
+}
+
+func TestNoRebootKnob(t *testing.T) {
+	conf := &Config{}
+
+	knobs := Knobs{
+		NoReboot: true,
+	}
+	knobsString := "--no-reboot"
+	mlockFalseString := "-realtime mlock=off"
+
+	testConfigAppend(conf, knobs, knobsString+" "+mlockFalseString, t)
 }
 
 var kernelString = "-kernel /opt/vmlinux.container -initrd /opt/initrd.container -append root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable"


### PR DESCRIPTION
The Kata architecture does not support rebooting VMs (the lifecycle
being start/exec/kill) and if a VM is killed (e.g. using sysrq-trigger),
the VM does not exit fully and other layers do not notice the state change.
Kata needs a way to tell QEMU to run with the '--no-reboot' option
so that the guest VM exits and does not attempt to reboot.

Add a NoReboot boolean Knob so when Knobs.NoReboot is set, the '--no-reboot'
command-line option will be passed to QEMU on startup.

Signed-off-by: Liam Merwick <liam.merwick@oracle.com>