### PR TITLE
qemu: add iommu_platform knob for qemuParams

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -406,6 +406,9 @@ func (fsdev FSDevice) QemuParams(config *Config) []string {
 		deviceParams = append(deviceParams, fmt.Sprintf(",romfile=%s", fsdev.ROMFile))
 	}
 	if fsdev.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			deviceParams = append(deviceParams, ",iommu_platform=on")
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf(",devno=%s", fsdev.DevNo))
 	}
 
@@ -537,6 +540,9 @@ func (cdev CharDevice) QemuParams(config *Config) []string {
 	}
 
 	if cdev.Driver == VirtioSerial && cdev.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			deviceParams = append(deviceParams, ",iommu_platform=on")
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf(",devno=%s", cdev.DevNo))
 	}
 
@@ -804,6 +810,9 @@ func (netdev NetDevice) QemuDeviceParams(config *Config) []string {
 	}
 
 	if netdev.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			deviceParams = append(deviceParams, ",iommu_platform=on")
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf(",devno=%s", netdev.DevNo))
 	}
 
@@ -937,6 +946,9 @@ func (dev SerialDevice) QemuParams(config *Config) []string {
 	}
 
 	if dev.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			deviceParams = append(deviceParams, ",iommu_platform=on")
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf(",devno=%s", dev.DevNo))
 	}
 
@@ -1528,6 +1540,9 @@ func (scsiCon SCSIController) QemuParams(config *Config) []string {
 	}
 
 	if scsiCon.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			devParams = append(devParams, ",iommu_platform=on")
+		}
 		devParams = append(devParams, fmt.Sprintf("devno=%s", scsiCon.DevNo))
 	}
 
@@ -1710,6 +1725,9 @@ func (vsock VSOCKDevice) QemuParams(config *Config) []string {
 	}
 
 	if vsock.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			deviceParams = append(deviceParams, ",iommu_platform=on")
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf(",devno=%s", vsock.DevNo))
 	}
 
@@ -1780,6 +1798,9 @@ func (v RngDevice) QemuParams(config *Config) []string {
 	}
 
 	if v.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			deviceParams = append(deviceParams, ",iommu_platform=on")
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf("devno=%s", v.DevNo))
 	}
 
@@ -2125,6 +2146,9 @@ type Knobs struct {
 
 	// Exit instead of rebooting
 	NoReboot bool
+
+	// IOMMUPlatform will enable IOMMU for supported devices
+	IOMMUPlatform bool
 }
 
 // IOThread allows IO to be performed on a separate thread.

--- a/qemu/qemu_s390x_test.go
+++ b/qemu/qemu_s390x_test.go
@@ -24,6 +24,7 @@ import "testing"
 // See https://wiki.qemu.org/Documentation/Platforms/S390X
 var (
 	deviceFSString                 = "-device virtio-9p-ccw,fsdev=workload9p,mount_tag=rootfs,devno=" + DevNo + " -fsdev local,id=workload9p,path=/var/lib/docker/devicemapper/mnt/e31ebda2,security_model=none,multidevs=remap"
+	deviceFSIOMMUString            = "-device virtio-9p-ccw,fsdev=workload9p,mount_tag=rootfs,iommu_platform=on,devno=" + DevNo + " -fsdev local,id=workload9p,path=/var/lib/docker/devicemapper/mnt/e31ebda2,security_model=none,multidevs=remap"
 	deviceNetworkString            = "-netdev tap,id=tap0,vhost=on,ifname=ceth0,downscript=no,script=no -device driver=virtio-net-ccw,netdev=tap0,mac=01:02:de:ad:be:ef,devno=" + DevNo
 	deviceNetworkStringMq          = "-netdev tap,id=tap0,vhost=on,fds=3:4 -device driver=virtio-net-ccw,netdev=tap0,mac=01:02:de:ad:be:ef,mq=on,devno=" + DevNo
 	deviceSerialString             = "-device virtio-serial-ccw,id=serial0,devno=" + DevNo
@@ -53,4 +54,55 @@ func TestAppendVirtioBalloon(t *testing.T) {
 
 	balloonDevice.DeflateOnOOM = true
 	testAppend(balloonDevice, deviceString+devnoOptios+OnDeflateOnOMM, t)
+}
+
+func TestAppendDeviceFSCCW(t *testing.T) {
+	defaultKnobs := Knobs{
+		NoUserConfig: true,
+	}
+
+	fsdev := FSDevice{
+		Driver:        Virtio9P,
+		FSDriver:      Local,
+		ID:            "workload9p",
+		Path:          "/var/lib/docker/devicemapper/mnt/e31ebda2",
+		MountTag:      "rootfs",
+		SecurityModel: None,
+		DisableModern: true,
+		ROMFile:       "efi-virtio.rom",
+		Multidev:      Remap,
+		Transport:     TransportCCW,
+		DevNo:         DevNo,
+	}
+
+	var config Config
+	config.Knobs = defaultKnobs
+
+	testConfigAppend(&config, fsdev, deviceFSString, t)
+}
+
+func TestAppendDeviceFSCCWIOMMU(t *testing.T) {
+	defaultKnobs := Knobs{
+		NoUserConfig:  true,
+		IOMMUPlatform: true,
+	}
+
+	fsdev := FSDevice{
+		Driver:        Virtio9P,
+		FSDriver:      Local,
+		ID:            "workload9p",
+		Path:          "/var/lib/docker/devicemapper/mnt/e31ebda2",
+		MountTag:      "rootfs",
+		SecurityModel: None,
+		DisableModern: true,
+		ROMFile:       "efi-virtio.rom",
+		Multidev:      Remap,
+		Transport:     TransportCCW,
+		DevNo:         DevNo,
+	}
+
+	var config Config
+	config.Knobs = defaultKnobs
+
+	testConfigAppend(&config, fsdev, deviceFSIOMMUString, t)
 }


### PR DESCRIPTION
Add knobs.IOMMUPlatform and iommu_platform=on options for ccw device for s390x, which is also OK to add same option for pci device in the future if need.

Signed-off-by: Qi Feng Huo <huoqif@cn.ibm.com>