### PR TITLE
Add support for hot-plugging IBM Adjunct Processor (AP) devices

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -123,6 +123,9 @@ const (
 	// VfioCCW is the vfio driver with CCW transport.
 	VfioCCW DeviceDriver = "vfio-ccw"
 
+	// VfioAP is the vfio driver with AP transport.
+	VfioAP DeviceDriver = "vfio-ap"
+
 	// VHostVSockPCI is a generic Vsock vhost device with PCI transport.
 	VHostVSockPCI DeviceDriver = "vhost-vsock-pci"
 

--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -1217,6 +1217,15 @@ func (q *QMP) ExecutePCIVFIOMediatedDeviceAdd(ctx context.Context, devID, sysfsd
 	return q.executeCommand(ctx, "device_add", args, nil)
 }
 
+// ExecuteAPVFIOMediatedDeviceAdd adds a VFIO mediated AP device to a QEMU instance using the device_add command.
+func (q *QMP) ExecuteAPVFIOMediatedDeviceAdd(ctx context.Context, sysfsdev string) error {
+	args := map[string]interface{}{
+		"driver":   VfioAP,
+		"sysfsdev": sysfsdev,
+	}
+	return q.executeCommand(ctx, "device_add", args, nil)
+}
+
 // isSocketIDSupported returns if the cpu driver supports the socket id option
 func isSocketIDSupported(driver string) bool {
 	if driver == "host-s390x-cpu" || driver == "host-powerpc64-cpu" {

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -1100,6 +1100,23 @@ func TestQMPPCIVFIOPCIeDeviceAdd(t *testing.T) {
 	<-disconnectedCh
 }
 
+func TestQMPAPVFIOMediatedDeviceAdd(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommand("device_add", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	sysfsDev := "/sys/devices/vfio_ap/matrix/a297db4a-f4c2-11e6-90f6-d3b88d6c9525"
+	err := q.ExecuteAPVFIOMediatedDeviceAdd(context.Background(), sysfsDev)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+}
+
 // Checks that CPU are correctly added using device_add
 func TestQMPCPUDeviceAdd(t *testing.T) {
 	drivers := []string{"host-x86_64-cpu", "host-s390x-cpu", "host-powerpc64-cpu"}


### PR DESCRIPTION
This adds `ExecuteAPVFIOMediatedDeviceAdd` to `qemu/qmp.go`, which executes a hot-plug for an IBM Adjunct Processor (AP) VFIO device ([kernel doc here](https://www.kernel.org/doc/html/latest/s390/vfio-ap.html)).
See also Issue [#491](https://github.com/kata-containers/kata-containers/issues/491) in the Kata Containers project.

/cc @alicefr

Fixes: #133

If this LGTY in general, I'd create a Do-Not-Merge re-vendoring PR in Kata first to ensure compatibility.