### PR TITLE
travis: Run coveralls after success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,7 @@ before_install:
 
 script:
    - go env
-   - $GOPATH/bin/goveralls -v -service=travis-ci
    - gometalinter --tests --vendor --disable-all --enable=misspell --enable=vet --enable=ineffassign --enable=gofmt --enable=gocyclo --cyclo-over=15 --enable=golint --enable=errcheck --enable=deadcode --enable=staticcheck -enable=gas ./...
+
+after_success:
+   - $GOPATH/bin/goveralls -repotoken $COVERALLS_TOKEN -v -service=travis-ci


### PR DESCRIPTION
Fix the following error:

```
Bad response status from coveralls: 422
{"message":"service_job_id (717167073) must be unique for Travis Jobs
not supplying a Coveralls Repo Token","error":true}
The command "$GOPATH/bin/goveralls -v -service=travis-ci" exited with 1.
```

fixes #135

Signed-off-by: Julio Montes <julio.montes@intel.com>