### PR TITLE
github: enable github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-on: ["push", "pull_request"]
+on: ["pull_request"]
 name: Unit tests
 jobs:
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,40 @@
+on: ["push", "pull_request"]
+name: Unit tests
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.13.x, 1.14.x, 1.15.x]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      GO111MODULE: off
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Setup GOPATH
+      run: |
+        gopath_org=$(go env GOPATH)/src/github.com/intel/
+        mkdir -p ${gopath_org}
+        ln -s ${PWD} ${gopath_org}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Install gometalinter
+      run: |
+        go get github.com/alecthomas/gometalinter
+        $(go env GOPATH)/bin/gometalinter --install
+    - name: Running gometalinter
+      run: |
+        gopath_repo=$(go env GOPATH)/src/github.com/intel/govmm
+        pushd ${gopath_repo}
+        $(go env GOPATH)/bin/gometalinter --tests --vendor --disable-all --enable=misspell --enable=vet --enable=ineffassign --enable=gofmt --enable=gocyclo --cyclo-over=15 --enable=golint --enable=errcheck --enable=deadcode --enable=staticcheck -enable=gas ./...
+    - name: Send coverage
+      env:
+        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gopath_repo=$(go env GOPATH)/src/github.com/intel/govmm
+        pushd ${gopath_repo}
+        go get github.com/mattn/goveralls
+        $(go env GOPATH)/bin/goveralls -v -service=github

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ go:
     - "1.11"
     - tip
 arch:
-    - amd64
     - s390x
 
 go_import_path: github.com/intel/govmm


### PR DESCRIPTION
Use github actions to run unit tests.
Github actions service looks more stable and reliable than travis.

fixes #136

Signed-off-by: Julio Montes <julio.montes@intel.com>