### PR TITLE
Add qom-get function

### DIFF
--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -1639,3 +1639,18 @@ func (q *QMP) ExecQomSet(ctx context.Context, path, property string, value uint6
 
 	return q.executeCommand(ctx, "qom-set", args, nil)
 }
+
+// ExecQomGet qom-get path property
+func (q *QMP) ExecQomGet(ctx context.Context, path, property string) (interface{}, error) {
+	args := map[string]interface{}{
+		"path":     path,
+		"property": property,
+	}
+
+	response, err := q.executeCommandWithResponse(ctx, "qom-get", args, nil, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return response, nil
+}

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -1770,3 +1770,27 @@ func TestExecQomSet(t *testing.T) {
 	q.Shutdown()
 	<-disconnectedCh
 }
+
+// Checks qom-get
+func TestExecQomGet(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommand("qom-get", nil, "return", "container")
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	val, err := q.ExecQomGet(context.Background(), "/", "type")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	vals, ok := val.(string)
+	if !ok {
+		t.Fatalf("Unexpected type in qom-get")
+	}
+	if vals != "container" {
+		t.Fatalf("Unpexected value in qom-get")
+	}
+	q.Shutdown()
+	<-disconnectedCh
+}


### PR DESCRIPTION
Add a function to access the qom-get QMP command so we can query
information from qemu.

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>